### PR TITLE
В при выполнении тестов пишем логи в консоль.

### DIFF
--- a/QS.LibsTest/NLog.config
+++ b/QS.LibsTest/NLog.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <targets>
+        <target name="console" xsi:type="Console" 
+        	layout="${date:format=HH\:MM\:ss} ${logger} ${message} ${onexception:${newline}${exception:format=tostring}}" />
+    </targets>
+
+    <rules>
+        <logger name="*" minlevel="debug" writeTo="console" />
+    </rules>
+</nlog>

--- a/QS.LibsTest/QS.LibsTest.csproj
+++ b/QS.LibsTest/QS.LibsTest.csproj
@@ -75,6 +75,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="NLog.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Banks\BanksUpdaterTests.cs" />


### PR DESCRIPTION
Сомневаюсь насколько это надо. Но вот понадобилось один раз, вдруг все поддержат и оставим.

Добавлен конфиг Nlog-а в проект с тестами, чтобы во время тестов все что падает из классов в Nlog, отправлялось во первых на консоль при запуске на машине разработчика, во вторых в дженкинсе отображалось в общем логе сборки. В некоторых сложных ситуациях, позволяет быстрее понять что же не так происходило при выполнении упавшего теста.

У меня нет уверенности что это удобно выводить именно в консоль на дженкинсе.