### PR TITLE
Установка нулевой задержки в поиске.

### DIFF
--- a/QS.Project.Gtk/Project.Search.GtkUI/SearchView.cs
+++ b/QS.Project.Gtk/Project.Search.GtkUI/SearchView.cs
@@ -16,7 +16,7 @@ namespace QS.Project.Search.GtkUI
 		/// Задержка в передачи запроса на поиск во view model.
 		/// Измеряется в милсекундах.
 		/// </summary>
-		public static uint QueryDelay = 1500;
+		public static uint QueryDelay = 0;
 		#endregion
 
 		SearchViewModel viewModel;


### PR DESCRIPTION
Ребята, давайте все таки по умолчанию будет задержка поиска нулевая.
Все таки водовоз это один проект. В котором будет стоять эта задержка. Иначе получается мне надо будет во всех проектах проставлять эту настройку в 0. Лучше мне кажется в одном проекте проставить такую настройку.

Во вторых, ваши пользователи видимо привыкли уже к этой задержке, мои нет. У меня во всех проектах еще старые журналы Representation, где нет таких больших задержек и фильтрация списков особенно простых справочников с меньшей чем 1000 количества элементов, происходит моментально. При внедрении новых журналов вместо старых, создается реальное впечатление что поиск тормозит, даже при 10 элементах в списке, в новых справочниках, по сравнению с другими которые не переведены еще.

P.S. для Вадима. Мне кажется что проталкивание таких изменений в комите  с названием "Исправлено имя поля", выглядит как-то по свински.
P.S. для Себя. Надо внимательнее проверять код.