### PR TITLE
Переделал передачу билдера в апдейтер.

### DIFF
--- a/QS.Project/Project.DB/Connection.cs
+++ b/QS.Project/Project.DB/Connection.cs
@@ -11,8 +11,5 @@ namespace QS.Project.DB
 
 		internal static Func<DbConnection> GetConnectionDB;
 		public static DbConnection ConnectionDB => GetConnectionDB();
-
-		internal static Func<MySqlConnectionStringBuilder> GetConnectionStringBuilder;
-		public static MySqlConnectionStringBuilder ConnectionStringBuilder => GetConnectionStringBuilder();
 	}
 }

--- a/QS.Updater.Gtk/DBUpdater/DBUpdater.cs
+++ b/QS.Updater.Gtk/DBUpdater/DBUpdater.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Gtk;
+using MySql.Data.MySqlClient;
 using QS.Dialog.GtkUI;
 using QS.Project.DB;
 using QS.Project.Dialogs.GtkUI.ServiceDlg;
@@ -145,7 +146,7 @@ namespace QS.Updater.DB
 			Environment.Exit(1);
 		}
 
-		public static void TryUpdate()
+		public static void TryUpdate(MySqlConnectionStringBuilder connectionStringBuilder)
 		{
 			logger.Debug (System.Reflection.Assembly.GetCallingAssembly().FullName);
 			Version currentDB = Version.Parse(MainSupport.BaseParameters.Version);
@@ -160,13 +161,12 @@ namespace QS.Updater.DB
 					NotAdminErrorAndExit(false, update.Source, update.Destanation);
 
 				//Увеличиваем время выполнения одной команды до 4 минут. При больших базах процесс обновления может вылетать по таймауту.
-				var builder = Project.DB.Connection.ConnectionStringBuilder;
-				builder.ConnectionTimeout = 240;
+				connectionStringBuilder.ConnectionTimeout = 240;
 
 				var dlg = new DBUpdateProcess (
 					update, 
 					new MySQLProvider(
-						builder.GetConnectionString(true), 
+						connectionStringBuilder.GetConnectionString(true), 
 						new GtkRunOperationService(), 
 						new GtkQuestionDialogsInteractive()));
 				dlg.Show ();
@@ -177,7 +177,7 @@ namespace QS.Updater.DB
 
 				MainSupport.LoadBaseParameters ();
 				if (appVersion.Major != update.Destanation.Major && appVersion.Minor != update.Destanation.Minor)
-					TryUpdate ();
+					TryUpdate (connectionStringBuilder);
 			}
 			else
 			{

--- a/QS.Updater.Gtk/DBUpdater/SQLDBUpdater.cs
+++ b/QS.Updater.Gtk/DBUpdater/SQLDBUpdater.cs
@@ -13,7 +13,7 @@ namespace QS.Updater
 
 		public void CheckUpdateDB()
 		{
-			DB.DBUpdater.TryUpdate();
+			DB.DBUpdater.TryUpdate(QSProjectsLib.QSMain.ConnectionStringBuilder);
 		}
 	}
 }

--- a/QSOrmProject/OrmMain.cs
+++ b/QSOrmProject/OrmMain.cs
@@ -244,7 +244,6 @@ namespace QSOrmProject
 			//FIXME Временные пробросы на этап перехода на QS.Project
 			QS.Project.Repositories.UserRepository.GetCurrentUserId = () => QSMain.User.Id;
 			QS.Project.DB.Connection.GetConnectionString = () => QSMain.ConnectionString;
-			QS.Project.DB.Connection.GetConnectionStringBuilder = () => QSMain.ConnectionStringBuilder;
 			QS.Project.DB.Connection.GetConnectionDB = () => QSMain.ConnectionDB;
 			QS.DomainModel.Config.DomainConfiguration.GetEntityConfig = (clazz) => GetObjectDescription(clazz) as IEntityConfig;
 			QS.Deletion.DeleteHelper.DeleteEntity = (clazz, id) => DeleteObject(clazz, id);


### PR DESCRIPTION
Во первых проблема возникает у проектов не использующих OrmProject, и линковать на него ради заполнения этого поля. нет.
Во вторых апдейтер все равно надо переделывать и отлинковывать его древней QSPojectsLib. А так как она слинкована уже пускай билдер сама возьмет
В третьи надо отказываться от статических настроек по максимуму. Поэтому так эта настройка все равно в будущем не нужна.