### PR TITLE
Решил поменять концепцию наименования пространства имен для UI

### DIFF
--- a/QS.Project.Gtk/QS.Project.Gtk.csproj
+++ b/QS.Project.Gtk/QS.Project.Gtk.csproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{3C0F3944-CBD5-4BD6-83D4-CF33AD6FC68C}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>QS</RootNamespace>
+    <RootNamespace>QS.GtkUI</RootNamespace>
     <AssemblyName>QS.Project.Gtk</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <ProductVersion>8.0.30703</ProductVersion>


### PR DESCRIPTION
Изначально предполагалось что будет вот такая схема.
QS.ModleName.Name - Код не связанный с UI
QS.ModleName.Name.GtkUI - Код UI
QS.ModleName.Name.WpfUI - Код UI

То есть, код каждого модуля лежит в аналогичном названии пространства имен, но с припиской вида интерфейса.  Вроде выглядит красиво, НО:
- Выбор нейспеса в автодополнии, зашел в "папку", а там тебе на выбор неймспейсы с разными GUI, собственно ради чего вся эта красота затевалась, не будет работать. Так как навряд ли будут проекты или библиотеки которые будут одновременно линковать несколько GUI и поэтому не имеет смысла держать неймспейсы как бы рядом.
- Концепция добавления GUI в конец не позволяет из имен папок делать иерархию, подпапок. Например QS.Views.GtkUI и QS.Views.Control.GtkUI уже не объединить иерархически в папки чтобы это было красиво и удобно для использования.

Поэтому решил поменять концепцию на такую:
QS.ModuleName.SubName - Код не связанный с UI
QS.GtkUI.ModuleName.SubName - Код UI
QS.WpfUI.ModuleName.SubName - Код UI
Так как разные UI все равно будут в разных библиотеках у них можно будет просто поставить префикс своего UI. А дальше структура папок может полностью соответствовать структуре с кодом не связанным с UI.