### PR TITLE
Пометил методы в классе DomainHelper как устаревшие.

### DIFF
--- a/QS.Project/DomainModel/Entity/DomainHelper.cs
+++ b/QS.Project/DomainModel/Entity/DomainHelper.cs
@@ -143,11 +143,13 @@ namespace QS.DomainModel.Entity
 			}
 		}
 
+		[Obsolete("Нужно в будущем выпилить отсюда этот метод. Во первых они полностью дублирую аналогичные в DialogHelper, во вторых они очень косвенно относятся к доменной модели и в DialogHelper им самое место.")]
 		public static string GenerateDialogHashName<TEntity>(int id) where TEntity : IDomainObject
 		{
 			return GenerateDialogHashName(typeof(TEntity), id);
 		}
 
+		[Obsolete("Нужно в будущем выпилить отсюда этот метод. Во первых они полностью дублирую аналогичные в DialogHelper, во вторых они очень косвенно относятся к доменной модели и в DialogHelper им самое место.")]
 		public static string GenerateDialogHashName(Type entityType, int id)
 		{
 			if(!typeof(IDomainObject).IsAssignableFrom(entityType))


### PR DESCRIPTION
Чтобы их по возможности не использовали и в будущем выпилили.
Считаю было не правильное решение запихать эти методы сюда. Нужно было, делать копию DialogHelper или что нибудь в этом роде. К доменной модели они мало имеют отношения. Что доказывать тот факт что в новых Диалогах они не нужны, а методы работы с доменной моделью нужны.
Сейчас переделывать уже слишком много, поэтому просто пометим как устаревшие.