### PR TITLE
Не падаем если TabParent = null

### DIFF
--- a/QS.Project/ViewModels/TabViewModelBase.cs
+++ b/QS.Project/ViewModels/TabViewModelBase.cs
@@ -91,9 +91,9 @@ namespace QS.ViewModels
 		public virtual void Close(bool askSave)
 		{
 			if(askSave)
-				TabParent.AskToCloseTab(this);
+				TabParent?.AskToCloseTab(this);
 			else
-				TabParent.ForceCloseTab(this);
+				TabParent?.ForceCloseTab(this);
 		}
 
 		public void OnTabClosed()


### PR DESCRIPTION
Для того чтобы можно было использовать новые журналы совсем без Tdi. Мешает только это. При выборе какой то строки, журнал пытается закрыть сам себя. А у него TabParent не заполнено, поэтом он падает.
В остальном базовый журнал полностью юзабельный без tdi.