### PR TITLE
Реализация еще одного менеджера навигации на окнах Gtk

### DIFF
--- a/QS.LibsTest/Project.Journal/EntityJournalViewModelBaseTest.cs
+++ b/QS.LibsTest/Project.Journal/EntityJournalViewModelBaseTest.cs
@@ -1,5 +1,6 @@
 ﻿using NSubstitute;
 using NUnit.Framework;
+using QS.Navigation;
 using QS.Project.Journal;
 using QS.Project.Journal.DataLoader;
 using QS.Services;
@@ -34,8 +35,9 @@ namespace QS.Test.Project.Journal
 				uow.Commit();
 
 				var interactiveService = Substitute.For<IInteractiveService>();
+				var navigationManager = Substitute.For<INavigationManager>();
 
-				var model = new FullQuerySetEntityJournalViewModel(UnitOfWorkFactory, interactiveService);
+				var model = new FullQuerySetEntityJournalViewModel(UnitOfWorkFactory, interactiveService, navigationManager);
 
 				ManualResetEvent oSignalEvent = new ManualResetEvent(false);
 				Exception treadException = null;

--- a/QS.LibsTest/TestApp/JournalViewModels/FullQuerySetEntityJournalViewModel.cs
+++ b/QS.LibsTest/TestApp/JournalViewModels/FullQuerySetEntityJournalViewModel.cs
@@ -2,6 +2,7 @@
 using NHibernate;
 using NHibernate.Transform;
 using QS.DomainModel.UoW;
+using QS.Navigation;
 using QS.Project.Journal;
 using QS.Services;
 using QS.Test.TestApp.Domain;
@@ -11,8 +12,8 @@ namespace QS.Test.TestApp.JournalViewModels
 {
 	public class FullQuerySetEntityJournalViewModel : EntityJournalViewModelBase<Document1, EntityViewModel, FullQuerySetDocumentJournalNode>
 	{
-		public FullQuerySetEntityJournalViewModel (IUnitOfWorkFactory unitOfWorkFactory,
-			IInteractiveService interactiveService) : base(unitOfWorkFactory, interactiveService)
+		public FullQuerySetEntityJournalViewModel (IUnitOfWorkFactory unitOfWorkFactory, IInteractiveService interactiveService, INavigationManager navigationManager) 
+			: base(unitOfWorkFactory, interactiveService, navigationManager)
 		{
 
 		}

--- a/QS.Project.Gtk/Navigation/AutofacViewModelsGtkPageFactory.cs
+++ b/QS.Project.Gtk/Navigation/AutofacViewModelsGtkPageFactory.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using QS.ViewModels;
+
+namespace QS.Navigation
+{
+	public class AutofacViewModelsGtkPageFactory : IViewModelsPageFactory
+	{
+		readonly IContainer Container;
+
+		public AutofacViewModelsGtkPageFactory(IContainer container)
+		{
+			Container = container;
+		}
+
+		public IPage<TViewModel> CreateViewModelNamedArgs<TViewModel>(DialogViewModelBase master, IDictionary<string, object> ctorArgs, string hash) where TViewModel : DialogViewModelBase
+		{
+			var scope = Container.BeginLifetimeScope();
+			var viewmodel = scope.Resolve<TViewModel>(ctorArgs.Select(pair => new NamedParameter(pair.Key, pair.Value)));
+			if(viewmodel is IAutofacScopeHolder)
+				(viewmodel as IAutofacScopeHolder).AutofacScope = scope;
+			var page = new GtkWindowPage<TViewModel>(viewmodel, hash);
+			page.PageClosed += (sender, e) => scope.Dispose();
+			return page;
+		}
+
+		public IPage<TViewModel> CreateViewModelTypedArgs<TViewModel>(DialogViewModelBase master, Type[] ctorTypes, object[] ctorValues, string hash) where TViewModel : DialogViewModelBase
+		{
+			var scope = Container.BeginLifetimeScope();
+			var viewmodel = scope.Resolve<TViewModel>(ctorTypes.Zip(ctorValues, (type, val) => new TypedParameter(type, val)));
+			if(viewmodel is IAutofacScopeHolder)
+				(viewmodel as IAutofacScopeHolder).AutofacScope = scope;
+			var page = new GtkWindowPage<TViewModel>(viewmodel, hash);
+			page.PageClosed += (sender, e) => scope.Dispose();
+			return page;
+		}
+	}
+}

--- a/QS.Project.Gtk/Navigation/GtkWindowPage.cs
+++ b/QS.Project.Gtk/Navigation/GtkWindowPage.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Gtk;
+using QS.Navigation;
+using QS.ViewModels;
+
+namespace QS.Navigation
+{
+	public class GtkWindowPage<TViewModel> : PageBase, IPage<TViewModel>, IGtkWindowPage
+		where TViewModel : DialogViewModelBase
+	{
+		public TViewModel ViewModel { get; private set; }
+
+		DialogViewModelBase IPage.ViewModel => ViewModel;
+
+		public Widget GtkView { get; set; }
+
+		public Gtk.Dialog GtkDialog { get; set; }
+
+		public GtkWindowPage(TViewModel viewModel, string hash)
+		{
+			ViewModel = viewModel;
+			PageHash = hash;
+		}
+
+	}
+}

--- a/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
@@ -55,6 +55,7 @@ namespace QS.Navigation
 			gtkPage.GtkView.Show();
 			gtkPage.GtkDialog.Show();
 			gtkPage.GtkDialog.Run();
+			ClosePage(page);
 			gtkPage.GtkDialog.Destroy();
 		}
 	}

--- a/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Gtk;
+using QS.Views.Resolve;
+
+namespace QS.Navigation
+{
+	public class GtkWindowsNavigationManager : NavigationManagerBase, INavigationManager
+	{
+		readonly IGtkViewResolver viewResolver;
+
+		public GtkWindowsNavigationManager(IPageHashGenerator hashGenerator, IViewModelsPageFactory viewModelsFactory, IGtkViewResolver viewResolver)
+			: base(hashGenerator, viewModelsFactory)
+		{
+			this.viewResolver = viewResolver;
+		}
+
+		#region Закрытие
+
+		public bool AskClosePage(IPage page)
+		{
+			throw new  NotImplementedException();
+		}
+
+		public void ForceClosePage(IPage page)
+		{
+			ClosePage(page);
+			(page as IGtkWindowPage).GtkDialog.Respond((int)ResponseType.DeleteEvent); 
+			(page as IGtkWindowPage).GtkView.Destroy();
+			(page as IGtkWindowPage).GtkDialog.Destroy();
+		}
+
+		#endregion
+
+		public override void SwitchOn(IPage page)
+		{
+			throw new NotImplementedException();
+		}
+
+		protected override void OpenSlavePage(IPage masterPage, IPage page)
+		{
+			OpenPage(masterPage, page);
+		}
+
+		protected override void OpenPage(IPage masterPage, IPage page)
+		{
+			pages.Add(page);
+			var gtkPage = (IGtkWindowPage)page;
+			var gtkMasterPage = (IGtkWindowPage)masterPage;
+			gtkPage.GtkView = viewResolver.Resolve(page.ViewModel);
+			gtkPage.GtkDialog = new Gtk.Dialog(gtkPage.ViewModel.Title, gtkMasterPage?.GtkDialog, DialogFlags.Modal);
+			gtkPage.GtkDialog.SetDefaultSize(800, 500);
+			gtkPage.GtkDialog.VBox.Add(gtkPage.GtkView);
+			gtkPage.GtkView.Show();
+			gtkPage.GtkDialog.Show();
+			gtkPage.GtkDialog.Run();
+			gtkPage.GtkDialog.Destroy();
+		}
+	}
+}

--- a/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
@@ -43,6 +43,8 @@ namespace QS.Navigation
 
 		protected override void OpenPage(IPage masterPage, IPage page)
 		{
+			//FIXME Временное решение пока не выпилим TDi, и реализуем заполнение этого через конструктор.
+			page.ViewModel.NavigationManager = this;
 			pages.Add(page);
 			var gtkPage = (IGtkWindowPage)page;
 			var gtkMasterPage = (IGtkWindowPage)masterPage;

--- a/QS.Project.Gtk/Navigation/IGtkWindowPage.cs
+++ b/QS.Project.Gtk/Navigation/IGtkWindowPage.cs
@@ -1,0 +1,11 @@
+﻿using Gtk;
+
+namespace QS.Navigation
+{
+	public interface IGtkWindowPage : IPage
+	{
+		Widget GtkView { get; set; }
+
+		Gtk.Dialog GtkDialog { get; set; }
+	}
+}

--- a/QS.Project.Gtk/Navigation/TdiNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/TdiNavigationManager.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using QS.Tdi;
 using QS.Tdi.Gtk;
@@ -10,67 +9,18 @@ namespace QS.Navigation
 	public class TdiNavigationManager : NavigationManagerBase, INavigationManager, ITdiCompatibilityNavigation
 	{
 		readonly TdiNotebook tdiNotebook;
-		readonly IPageHashGenerator hashGenerator;
-		readonly IViewModelsPageFactory viewModelsFactory;
+
 		//Только для режима смешанного использования Tdi и ViewModel 
 		readonly ITdiPageFactory tdiPageFactory;
 
 		public TdiNavigationManager(TdiNotebook tdiNotebook, IPageHashGenerator hashGenerator, IViewModelsPageFactory viewModelsFactory, ITdiPageFactory tdiPageFactory = null)
+			: base(hashGenerator, viewModelsFactory)
 		{
 			this.tdiNotebook = tdiNotebook ?? throw new ArgumentNullException(nameof(tdiNotebook));
-			this.hashGenerator = hashGenerator ?? throw new ArgumentNullException(nameof(hashGenerator));
-			this.viewModelsFactory = viewModelsFactory ?? throw new ArgumentNullException(nameof(viewModelsFactory));
 			this.tdiPageFactory = tdiPageFactory;
 
 			tdiNotebook.TabClosed += TdiNotebook_TabClosed;
 		}
-
-		#region Перебор страниц
-		private readonly List<IPage> pages = new List<IPage>();
-
-		public IEnumerable<IPage> AllPages {
-			get {
-				foreach (var page in pages) {
-					yield return page;
-					foreach (var child in page.ChildPagesAll)
-						yield return child.ChildPage;
-				}
-			}
-		}
-
-		public IEnumerable<IPage> TopLevelPages => pages;
-
-		public IEnumerable<IPage> IndependentPages {
-			get {
-				foreach (var page in pages) {
-					if (SlavePages.All(x => x.SlavePage != page))
-						yield return page;
-					foreach (var child in page.ChildPagesAll)
-						if (SlavePages.All(x => x.SlavePage != child))
-							yield return child.ChildPage;
-				}
-			}
-		}
-
-		public IEnumerable<MasterToSlavePair> SlavePages {
-			get {
-				foreach (var page in pages) {
-					foreach (var slavePair in page.SlavePagesAll)
-						yield return slavePair;
-				}
-			}
-		}
-
-		public IEnumerable<ParentToChildPair> ChildPages {
-			get {
-				foreach (var page in pages) {
-					foreach (var childPair in page.ChildPagesAll)
-						yield return childPair;
-				}
-			}
-		}
-
-		#endregion
 
 		#region Закрытие
 
@@ -92,133 +42,11 @@ namespace QS.Navigation
 			else
 				closedTab = e.Tab;
 
-			var closedPagePair = SlavePages.FirstOrDefault(x => (x.SlavePage as ITdiPage).TdiTab == closedTab);
-			if (closedPagePair != null)
-				(closedPagePair.MasterPage as IPageInternal).RemoveSlavePage(closedPagePair.SlavePage);
-			var pageToRemove = pages.Cast<ITdiPage>().FirstOrDefault(x => x.TdiTab == closedTab);
-			if(pageToRemove != null) {
-				pages.Remove(pageToRemove);
-				(pageToRemove as IPageInternal).OnClosed();
-			}
-			else {
-				var childPair = ChildPages.FirstOrDefault(x => (x.ChildPage as ITdiPage).TdiTab == closedTab);
-				if(childPair != null) {
-					(childPair.ParentPage as IPageInternal).RemoveChildPage(childPair.ChildPage);
-					(childPair.ChildPage as IPageInternal).OnClosed();
-				}
-			}
+			var page = FindPage(closedTab);
+			if (page != null)
+				ClosePage(page);
 		}
 
-		#endregion
-
-		#region Поиск
-
-		public IPage FindPage(ViewModelBase viewModel)
-		{
-			return AllPages.FirstOrDefault(x => x.ViewModel == viewModel);
-		}
-
-		public IPage<TViewModel> FindPage<TViewModel>(TViewModel viewModel) where TViewModel : ViewModelBase
-		{
-			return FindPage(viewModel);
-		}
-
-		#endregion
-
-		#region Открытие
-
-		public IPage<TViewModel> OpenViewModel<TViewModel>(ViewModelBase master, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase
-		{
-			var types = new Type[] { };
-			var values = new object[] { };
-			return OpenViewModelTypedArgs<TViewModel>(master, types, values, options);
-		}
-
-		public IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1>(ViewModelBase master, TCtorArg1 arg1, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase
-		{
-			var types = new Type[] { typeof(TCtorArg1) };
-			var values = new object[] { arg1 };
-			return OpenViewModelTypedArgs<TViewModel>(master, types, values, options);
-		}
-
-		public IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1, TCtorArg2>(ViewModelBase master, TCtorArg1 arg1, TCtorArg1 arg2, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase
-		{
-			var types = new Type[] { typeof(TCtorArg1), typeof(TCtorArg2) };
-			var values = new object[] { arg1, arg2 };
-			return OpenViewModelTypedArgs<TViewModel>(master, types, values, options);
-		}
-
-		public IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1, TCtorArg2, TCtorArg3>(ViewModelBase master, TCtorArg1 arg1, TCtorArg1 arg2, TCtorArg1 arg3, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase
-		{
-			var types = new Type[] { typeof(TCtorArg1), typeof(TCtorArg2), typeof(TCtorArg3) };
-			var values = new object[] { arg1, arg2, arg3 };
-			return OpenViewModelTypedArgs<TViewModel>(master, types, values, options);
-		}
-
-		public IPage<TViewModel> OpenViewModelTypedArgs<TViewModel>(ViewModelBase master, Type[] ctorTypes, object[] ctorValues, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase
-		{
-			return (IPage<TViewModel>)OpenViewModelInternal(
-				FindPage(master), options, 
-				() => hashGenerator.GetHash<TViewModel>(master, ctorTypes, ctorValues),
-				(hash) => viewModelsFactory.CreateViewModelTypedArgs<TViewModel>(master, ctorTypes, ctorValues, hash)
-			);
-		}
-
-		public IPage<TViewModel> OpenViewModelNamedArgs<TViewModel>(ViewModelBase master, IDictionary<string, object> ctorArgs, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase
-		{
-			return (IPage<TViewModel>)OpenViewModelInternal(
-				FindPage(master), options,
-				() => hashGenerator.GetHashNamedArgs<TViewModel>(master, ctorArgs),
-				(hash) => viewModelsFactory.CreateViewModelNamedArgs<TViewModel>(master, ctorArgs, hash)
-			);
-		}
-
-		#region Внутренне
-
-		private IPage OpenViewModelInternal(IPage masterPage, OpenPageOptions options, Func<string> makeHash, Func<string, IPage> makePage)
-		{
-			string hash = null;
-			if (!options.HasFlag(OpenPageOptions.IgnoreHash))
-				hash = makeHash();
-
-			ITdiPage openPage = null;
-
-			if (options.HasFlag(OpenPageOptions.AsSlave)) {
-				if (masterPage == null)
-					throw new InvalidOperationException($"Отсутствует главная страница для добавляемой подчиненой страницы.");
-
-				if (hash != null)
-					openPage = (ITdiPage)masterPage.SlavePagesAll.Select(x => x.SlavePage).FirstOrDefault(x => x.PageHash == hash);
-				if (openPage != null)
-					SwitchOn(openPage);
-				else {
-					openPage = (ITdiPage)makePage(hash);
-					tdiNotebook.AddSlaveTab((masterPage as ITdiPage).TdiTab, openPage.TdiTab);
-					(masterPage as IPageInternal).AddSlavePage(openPage);
-					pages.Add(openPage);
-				}
-			}
-			else {
-				if (hash != null)
-					openPage = (ITdiPage)IndependentPages.FirstOrDefault(x => x.PageHash == hash);
-				if (openPage != null)
-					SwitchOn(openPage);
-				else {
-					openPage = (ITdiPage)makePage(hash);
-					var masterTab = (masterPage as ITdiPage)?.TdiTab;
-					if (masterTab is ITdiJournal && masterTab.TabParent is TdiSliderTab) {
-						var slider = masterTab.TabParent as TdiSliderTab;
-						slider.AddTab(openPage.TdiTab, masterTab);
-						(masterPage as IPageInternal).AddChildPage(openPage);
-					}
-					else {
-						tdiNotebook.AddTab(openPage.TdiTab, masterTab);
-						pages.Add(openPage);
-					}
-				}
-			}
-			return openPage;
-		}
 		#endregion
 
 		#region ITdiCompatibilityNavigation
@@ -273,6 +101,11 @@ namespace QS.Navigation
 
 		#endregion
 
+		private IPage FindPage(ITdiTab tab)
+		{
+			return AllPages.OfType<ITdiPage>().FirstOrDefault(x => x.TdiTab == tab);
+		}
+
 		private IPage FindOrCreateMasterPage(ITdiTab tab)
 		{
 			ITdiPage page = AllPages.OfType<ITdiPage>().FirstOrDefault(x => x.TdiTab == tab);
@@ -284,11 +117,30 @@ namespace QS.Navigation
 
 		#endregion
 
-		#endregion
-
-		public void SwitchOn(IPage page)
+		public override void SwitchOn(IPage page)
 		{
 			tdiNotebook.SwitchOnTab((ITdiTab)page.ViewModel);
+		}
+
+		protected override void OpenSlavePage(IPage masterPage, IPage page)
+		{
+			pages.Add(page);
+			tdiNotebook.AddSlaveTab((masterPage as ITdiPage).TdiTab, (page as ITdiPage).TdiTab);
+		}
+
+		protected override void OpenPage(IPage masterPage, IPage page)
+		{
+			var masterTab = (masterPage as ITdiPage)?.TdiTab;
+
+			if (masterTab is ITdiJournal && masterTab.TabParent is TdiSliderTab) {
+				var slider = masterTab.TabParent as TdiSliderTab;
+				slider.AddTab((page as ITdiPage).TdiTab, masterTab);
+				(masterPage as IPageInternal).AddChildPage(page);
+			}
+			else {
+				pages.Add(page);
+				tdiNotebook.AddTab((page as ITdiPage).TdiTab, (masterPage as ITdiPage)?.TdiTab);
+			}
 		}
 	}
 }

--- a/QS.Project.Gtk/Navigation/TdiNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/TdiNavigationManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using QS.Tdi;
@@ -7,7 +7,7 @@ using QS.ViewModels;
 
 namespace QS.Navigation
 {
-	public class TdiNavigationManager : INavigationManager, ITdiCompatibilityNavigation
+	public class TdiNavigationManager : NavigationManagerBase, INavigationManager, ITdiCompatibilityNavigation
 	{
 		readonly TdiNotebook tdiNotebook;
 		readonly IPageHashGenerator hashGenerator;
@@ -225,14 +225,14 @@ namespace QS.Navigation
 
 		#region Открытие ViewModel
 
-		public IPage<TViewModel> OpenViewModelOnTdi<TViewModel>(ITdiTab master, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase
+		public IPage<TViewModel> OpenViewModelOnTdi<TViewModel>(ITdiTab master, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase
 		{
 			var types = new Type[] { };
 			var values = new object[] { };
 			return OpenViewModelOnTdiTypedArgs<TViewModel>(master, types, values, options);
 		}
 
-		public IPage<TViewModel> OpenViewModelOnTdiTypedArgs<TViewModel>(ITdiTab master, Type[] ctorTypes, object[] ctorValues, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase
+		public IPage<TViewModel> OpenViewModelOnTdiTypedArgs<TViewModel>(ITdiTab master, Type[] ctorTypes, object[] ctorValues, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase
 		{
 			return (IPage<TViewModel>)OpenViewModelInternal(
 				FindOrCreateMasterPage(master), options,

--- a/QS.Project.Gtk/QS.Project.Gtk.csproj
+++ b/QS.Project.Gtk/QS.Project.Gtk.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Widgets\ValidatedEntry.cs" />
     <Compile Include="Views\Resolve\ClassNamesBaseGtkViewResolver.cs" />
     <Compile Include="Views\Resolve\IGtkViewResolver.cs" />
+    <Compile Include="Views\Resolve\RegisteredGtkViewResolver.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Widgets.GtkUI\" />

--- a/QS.Project.Gtk/QS.Project.Gtk.csproj
+++ b/QS.Project.Gtk/QS.Project.Gtk.csproj
@@ -235,6 +235,10 @@
     <Compile Include="Navigation\AutofacTdiPageFactory.cs" />
     <Compile Include="Navigation\ITdiPageFactory.cs" />
     <Compile Include="Widgets\ValidatedEntry.cs" />
+    <Compile Include="Navigation\GtkWindowPage.cs" />
+    <Compile Include="Navigation\IGtkWindowPage.cs" />
+    <Compile Include="Navigation\GtkWindowsNavigationManager.cs" />
+    <Compile Include="Navigation\AutofacViewModelsGtkPageFactory.cs" />
     <Compile Include="Views\Resolve\ClassNamesBaseGtkViewResolver.cs" />
     <Compile Include="Views\Resolve\IGtkViewResolver.cs" />
     <Compile Include="Views\Resolve\RegisteredGtkViewResolver.cs" />

--- a/QS.Project.Gtk/QS.Project.Gtk.csproj
+++ b/QS.Project.Gtk/QS.Project.Gtk.csproj
@@ -235,6 +235,8 @@
     <Compile Include="Navigation\AutofacTdiPageFactory.cs" />
     <Compile Include="Navigation\ITdiPageFactory.cs" />
     <Compile Include="Widgets\ValidatedEntry.cs" />
+    <Compile Include="Views\Resolve\ClassNamesBaseGtkViewResolver.cs" />
+    <Compile Include="Views\Resolve\IGtkViewResolver.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Widgets.GtkUI\" />
@@ -259,6 +261,7 @@
     <Folder Include="Views\" />
     <Folder Include="Views\Control\" />
     <Folder Include="Widgets\" />
+    <Folder Include="Views\Resolve\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\GammaBinding\GammaBinding\GammaBinding.csproj">

--- a/QS.Project.Gtk/Views/Resolve/ClassNamesBaseGtkViewResolver.cs
+++ b/QS.Project.Gtk/Views/Resolve/ClassNamesBaseGtkViewResolver.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Gtk;
+using QS.ViewModels;
+
+namespace QS.Views.Resolve
+{
+	/// <summary>
+	/// Для работы этого резолвера классы должны распологаться в проекте по следущим правилам:
+	/// {CoreNamespace}.ViewModels.{SubNamespaces}.{Name}ViewModel - для модели представления
+	/// {CoreNamespace}.Views.{SubNamespaces}.{Name}View - для gtk представления
+	/// 
+	/// Все проименованные части имени у классов должны быть одинаковые, тогда автоматический подбор сработает.
+	/// {CoreNamespace} - Любое корневое пространство имен, любой вложенности.
+	/// {SubNamespaces} - Подпапки постранств имен любой вложенности указывающие на модуль или тематику класса.
+	/// {Name} - Непосредственно название диалога.
+	/// </summary>
+	public class ClassNamesBaseGtkViewResolver : IGtkViewResolver
+	{
+		Assembly[] lookupAssemblies;
+
+		public ClassNamesBaseGtkViewResolver(params Assembly[] lookupAssemblies)
+		{
+			this.lookupAssemblies = lookupAssemblies;
+		}
+
+		public Widget Resolve(DialogViewModelBase viewModel)
+		{
+			var fullClassName = viewModel.GetType().FullName;
+			var match = Regex.Matches(fullClassName, "^([a-zA-Z\\.]+)\\.ViewModels\\.([a-zA-Z\\.]+)\\.([a-zA-Z]+)ViewModel$");
+			if(match.Count != 1)
+				throw new InvalidOperationException($"Имя класса {fullClassName} не соответствует шаблону `[CoreNamespace].ViewModels.[SubNamespaces].[Name]ViewModel`");
+			var groups = match[0].Groups;
+			var expectedViewName = $"{groups[1].Value}.Views.{groups[2].Value}.{groups[3].Value}View";
+
+			foreach(var assambly in lookupAssemblies) {
+				Type viewClass = assambly.GetType(expectedViewName);
+				if(viewClass != null) {
+					return (Widget)Activator.CreateInstance(viewClass, viewModel);
+				}
+			}
+
+			return null;
+		}
+	}
+}

--- a/QS.Project.Gtk/Views/Resolve/IGtkViewResolver.cs
+++ b/QS.Project.Gtk/Views/Resolve/IGtkViewResolver.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Gtk;
+using QS.ViewModels;
+
+namespace QS.Views.Resolve
+{
+	public interface IGtkViewResolver
+	{
+		Widget Resolve(DialogViewModelBase viewModel);
+	}
+}

--- a/QS.Project.Gtk/Views/Resolve/RegisteredGtkViewResolver.cs
+++ b/QS.Project.Gtk/Views/Resolve/RegisteredGtkViewResolver.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using Gtk;
+using QS.ViewModels;
+
+namespace QS.Views.Resolve
+{
+	public class RegisteredGtkViewResolver : IGtkViewResolver
+	{
+		List<ResolveRule> registeredViews = new List<ResolveRule>();
+		readonly IGtkViewResolver nextResolver;
+
+		public RegisteredGtkViewResolver(IGtkViewResolver nextResolver)
+		{
+			this.nextResolver = nextResolver;
+		}
+
+		#region Fluent
+
+		/// <summary>
+		/// Регистрируем соответсвие между ViewModel и View.
+		/// </summary>
+		/// <returns>The view.</returns>
+		/// <typeparam name="TViewModel">Тип ViewModel, может быть интерфейсом или базовым классом, для регистрации одного View ко многим реализациям ViewModel</typeparam>
+		/// <typeparam name="TView">Тип View</typeparam>
+		public RegisteredGtkViewResolver RegisterView<TViewModel, TView>()
+			where TViewModel : DialogViewModelBase
+			where TView : Widget
+		{
+			registeredViews.Add(new ResolveRule(typeof(TViewModel), typeof(TView)));
+			return this;
+		}
+
+		#endregion
+
+		public Widget Resolve(DialogViewModelBase viewModel)
+		{
+			foreach(var rule in registeredViews) {
+				if(rule.IsMath(viewModel))
+					return rule.CreateView(viewModel);
+			}
+
+			return nextResolver.Resolve(viewModel);
+		}
+	}
+
+	internal class ResolveRule
+	{
+		readonly Type ViewModelType;
+		readonly Type ViewType;
+
+		public ResolveRule(Type viewModel, Type view)
+		{
+			ViewModelType = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+			ViewType = view ?? throw new ArgumentNullException(nameof(view));
+		}
+
+		public bool IsMath(DialogViewModelBase viewModel)
+		{
+			return ViewModelType.IsAssignableFrom(viewModel.GetType());
+		}
+
+		public Widget CreateView(DialogViewModelBase viewModel)
+		{
+			return (Widget)Activator.CreateInstance(ViewType, viewModel);
+		}
+	}
+}

--- a/QS.Project/Navigation/AutofacViewModelsPageFactory.cs
+++ b/QS.Project/Navigation/AutofacViewModelsPageFactory.cs
@@ -15,7 +15,7 @@ namespace QS.Navigation
 			Container = container;
 		}
 
-		public IPage<TViewModel> CreateViewModelNamedArgs<TViewModel>(ViewModelBase master, IDictionary<string, object> ctorArgs, string hash) where TViewModel : ViewModelBase
+		public IPage<TViewModel> CreateViewModelNamedArgs<TViewModel>(DialogViewModelBase master, IDictionary<string, object> ctorArgs, string hash) where TViewModel : DialogViewModelBase
 		{
 			var scope = Container.BeginLifetimeScope();
 			var viewmodel = scope.Resolve<TViewModel>(ctorArgs.Select(pair => new NamedParameter(pair.Key, pair.Value)));
@@ -26,7 +26,7 @@ namespace QS.Navigation
 			return page;
 		}
 
-		public IPage<TViewModel> CreateViewModelTypedArgs<TViewModel>(ViewModelBase master, Type[] ctorTypes, object[] ctorValues, string hash) where TViewModel : ViewModelBase
+		public IPage<TViewModel> CreateViewModelTypedArgs<TViewModel>(DialogViewModelBase master, Type[] ctorTypes, object[] ctorValues, string hash) where TViewModel : DialogViewModelBase
 		{
 			var scope = Container.BeginLifetimeScope();
 			var viewmodel = scope.Resolve<TViewModel>(ctorTypes.Zip(ctorValues, (type, val) => new TypedParameter(type, val)));

--- a/QS.Project/Navigation/ClassNamesHashGenerator.cs
+++ b/QS.Project/Navigation/ClassNamesHashGenerator.cs
@@ -17,12 +17,12 @@ namespace QS.Navigation
 
 		#region IPageHashGenerator
 
-		public string GetHash<TViewModel>(ViewModelBase master, Type[] ctorTypes, object[] ctorValues)
+		public string GetHash<TViewModel>(DialogViewModelBase master, Type[] ctorTypes, object[] ctorValues)
 		{
 			return InternalGetHash(typeof(TViewModel), ctorValues);
 		}
 
-		public string GetHashNamedArgs<TViewModel>(ViewModelBase master, IDictionary<string, object> ctorArgs)
+		public string GetHashNamedArgs<TViewModel>(DialogViewModelBase master, IDictionary<string, object> ctorArgs)
 		{
 			return InternalGetHash(typeof(TViewModel), ctorArgs.Values.ToArray());
 		}

--- a/QS.Project/Navigation/INavigationManager.cs
+++ b/QS.Project/Navigation/INavigationManager.cs
@@ -25,7 +25,8 @@ namespace QS.Navigation
 		IPage<TViewModel> OpenViewModelTypedArgs<TViewModel>(DialogViewModelBase master, Type[] ctorTypes, object[] ctorValues, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase;
 		IPage<TViewModel> OpenViewModelNamedArgs<TViewModel>(DialogViewModelBase master, IDictionary<string, object> ctorArgs, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase;
 
-		IPage<TViewModel> FindPage<TViewModel>(TViewModel viewModel) where TViewModel : DialogViewModelBase;
+		IPage FindPage(DialogViewModelBase viewModel);
+		IPage<TViewModel> FindPage<TViewModel>(DialogViewModelBase viewModel) where TViewModel : DialogViewModelBase;
 
 		void SwitchOn(IPage page);
 

--- a/QS.Project/Navigation/INavigationManager.cs
+++ b/QS.Project/Navigation/INavigationManager.cs
@@ -17,15 +17,15 @@ namespace QS.Navigation
 		/// передана страница после которой следует разместить созданную или null для размещения в конце списка.</param>
 		/// <param name="options">Параметры режима открытия.</param>
 		/// <typeparam name="TViewModel">Тип ViewModel которую необходимо создать.</typeparam>
-		IPage<TViewModel> OpenViewModel<TViewModel>(ViewModelBase master, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase;
-		IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1>(ViewModelBase master, TCtorArg1 arg1, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase;
-		IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1, TCtorArg2>(ViewModelBase master, TCtorArg1 arg1, TCtorArg1 arg2, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase;
-		IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1, TCtorArg2, TCtorArg3>(ViewModelBase master, TCtorArg1 arg1, TCtorArg1 arg2, TCtorArg1 arg3, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase;
+		IPage<TViewModel> OpenViewModel<TViewModel>(DialogViewModelBase master, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase;
+		IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1>(DialogViewModelBase master, TCtorArg1 arg1, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase;
+		IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1, TCtorArg2>(DialogViewModelBase master, TCtorArg1 arg1, TCtorArg1 arg2, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase;
+		IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1, TCtorArg2, TCtorArg3>(DialogViewModelBase master, TCtorArg1 arg1, TCtorArg1 arg2, TCtorArg1 arg3, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase;
 
-		IPage<TViewModel> OpenViewModelTypedArgs<TViewModel>(ViewModelBase master, Type[] ctorTypes, object[] ctorValues, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase;
-		IPage<TViewModel> OpenViewModelNamedArgs<TViewModel>(ViewModelBase master, IDictionary<string, object> ctorArgs, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase;
+		IPage<TViewModel> OpenViewModelTypedArgs<TViewModel>(DialogViewModelBase master, Type[] ctorTypes, object[] ctorValues, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase;
+		IPage<TViewModel> OpenViewModelNamedArgs<TViewModel>(DialogViewModelBase master, IDictionary<string, object> ctorArgs, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase;
 
-		IPage<TViewModel> FindPage<TViewModel>(TViewModel viewModel) where TViewModel : ViewModelBase;
+		IPage<TViewModel> FindPage<TViewModel>(TViewModel viewModel) where TViewModel : DialogViewModelBase;
 
 		void SwitchOn(IPage page);
 
@@ -39,8 +39,8 @@ namespace QS.Navigation
 	/// </summary>
 	public interface ITdiCompatibilityNavigation : INavigationManager
 	{
-		IPage<TViewModel> OpenViewModelOnTdi<TViewModel>(Tdi.ITdiTab master, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase;
-		IPage<TViewModel> OpenViewModelOnTdiTypedArgs<TViewModel>(Tdi.ITdiTab master, Type[] ctorTypes, object[] ctorValues, OpenPageOptions options = OpenPageOptions.None) where TViewModel : ViewModelBase;
+		IPage<TViewModel> OpenViewModelOnTdi<TViewModel>(Tdi.ITdiTab master, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase;
+		IPage<TViewModel> OpenViewModelOnTdiTypedArgs<TViewModel>(Tdi.ITdiTab master, Type[] ctorTypes, object[] ctorValues, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase;
 
 		ITdiPage OpenTdiTab<TTab>(ITdiTab masterTab, OpenPageOptions options = OpenPageOptions.None) where TTab : ITdiTab;
 		ITdiPage OpenTdiTab<TTab, TCtorArg1>(ITdiTab masterTab, TCtorArg1 arg1, OpenPageOptions options = OpenPageOptions.None) where TTab : ITdiTab;

--- a/QS.Project/Navigation/IPage.cs
+++ b/QS.Project/Navigation/IPage.cs
@@ -13,7 +13,7 @@ namespace QS.Navigation
 		/// </summary>
 		string PageHash { get; }
 
-		ViewModelBase ViewModel { get; }
+		DialogViewModelBase ViewModel { get; }
 
 		event EventHandler PageClosed;
 
@@ -42,7 +42,7 @@ namespace QS.Navigation
 	}
 
 	public interface IPage<TViewModel> : IPage
-		where TViewModel : ViewModelBase
+		where TViewModel : DialogViewModelBase
 	{
 		new TViewModel ViewModel { get; }
 	}

--- a/QS.Project/Navigation/IPageHashGenerator.cs
+++ b/QS.Project/Navigation/IPageHashGenerator.cs
@@ -6,7 +6,7 @@ namespace QS.Navigation
 {
 	public interface IPageHashGenerator
 	{
-		string GetHash<TViewModel>(ViewModelBase master, Type[] ctorTypes, object[] ctorValues);
-		string GetHashNamedArgs<TViewModel>(ViewModelBase master, IDictionary<string, object> ctorArgs);
+		string GetHash<TViewModel>(DialogViewModelBase master, Type[] ctorTypes, object[] ctorValues);
+		string GetHashNamedArgs<TViewModel>(DialogViewModelBase master, IDictionary<string, object> ctorArgs);
 	}
 }

--- a/QS.Project/Navigation/IViewModelsPageFactory.cs
+++ b/QS.Project/Navigation/IViewModelsPageFactory.cs
@@ -6,8 +6,8 @@ namespace QS.Navigation
 {
 	public interface IViewModelsPageFactory
 	{
-		IPage<TViewModel> CreateViewModelTypedArgs<TViewModel>(ViewModelBase master, Type[] ctorTypes, object[] ctorValues, string hash) where TViewModel : ViewModelBase;
+		IPage<TViewModel> CreateViewModelTypedArgs<TViewModel>(DialogViewModelBase master, Type[] ctorTypes, object[] ctorValues, string hash) where TViewModel : DialogViewModelBase;
 
-		IPage<TViewModel> CreateViewModelNamedArgs<TViewModel>(ViewModelBase master, IDictionary<string, object> ctorArgs, string hash) where TViewModel : ViewModelBase;
+		IPage<TViewModel> CreateViewModelNamedArgs<TViewModel>(DialogViewModelBase master, IDictionary<string, object> ctorArgs, string hash) where TViewModel : DialogViewModelBase;
 	}
 }

--- a/QS.Project/Navigation/NavigationManagerBase.cs
+++ b/QS.Project/Navigation/NavigationManagerBase.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using QS.Tdi;
 using QS.ViewModels;
 
 namespace QS.Navigation
@@ -71,9 +70,12 @@ namespace QS.Navigation
 			return AllPages.FirstOrDefault(x => x.ViewModel == viewModel);
 		}
 
-		public IPage<TViewModel> FindPage<TViewModel>(TViewModel viewModel) where TViewModel : DialogViewModelBase
+		//Внимание здесь специально параметр viewModel не является типом приведения результата TViewModel, так как если 
+		//бы viewModel была типом TViewModel, то в вызове можно было бы не указывать Generic тип, а это бы приводило к 
+		//попытке каста в IPage<DialogViewModelBase> при передаче не типизированного VM.
+		public IPage<TViewModel> FindPage<TViewModel>(DialogViewModelBase viewModel) where TViewModel : DialogViewModelBase
 		{
-			return FindPage(viewModel);
+			return (IPage<TViewModel>)FindPage(viewModel);
 		}
 
 		#endregion

--- a/QS.Project/Navigation/NavigationManagerBase.cs
+++ b/QS.Project/Navigation/NavigationManagerBase.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using QS.Tdi;
+using QS.ViewModels;
+
+namespace QS.Navigation
+{
+	public abstract class NavigationManagerBase
+	{
+		protected readonly IPageHashGenerator hashGenerator;
+		protected readonly IViewModelsPageFactory viewModelsFactory;
+
+		protected NavigationManagerBase(IPageHashGenerator hashGenerator, IViewModelsPageFactory viewModelsFactory)
+		{
+			this.hashGenerator = hashGenerator ?? throw new ArgumentNullException(nameof(hashGenerator));
+			this.viewModelsFactory = viewModelsFactory ?? throw new ArgumentNullException(nameof(viewModelsFactory));
+		}
+
+		#region Перебор страниц
+		protected readonly List<IPage> pages = new List<IPage>();
+
+		public IEnumerable<IPage> AllPages {
+			get {
+				foreach(var page in pages) {
+					yield return page;
+					foreach(var child in page.ChildPagesAll)
+						yield return child.ChildPage;
+				}
+			}
+		}
+
+		public IEnumerable<IPage> TopLevelPages => pages;
+
+		public IEnumerable<IPage> IndependentPages {
+			get {
+				foreach(var page in pages) {
+					if(SlavePages.All(x => x.SlavePage != page))
+						yield return page;
+					foreach(var child in page.ChildPagesAll)
+						if(SlavePages.All(x => x.SlavePage != child))
+							yield return child.ChildPage;
+				}
+			}
+		}
+
+		public IEnumerable<MasterToSlavePair> SlavePages {
+			get {
+				foreach(var page in pages) {
+					foreach(var slavePair in page.SlavePagesAll)
+						yield return slavePair;
+				}
+			}
+		}
+
+		public IEnumerable<ParentToChildPair> ChildPages {
+			get {
+				foreach(var page in pages) {
+					foreach(var childPair in page.ChildPagesAll)
+						yield return childPair;
+				}
+			}
+		}
+
+		#endregion
+
+		#region Поиск
+
+		public IPage FindPage(DialogViewModelBase viewModel)
+		{
+			return AllPages.FirstOrDefault(x => x.ViewModel == viewModel);
+		}
+
+		public IPage<TViewModel> FindPage<TViewModel>(TViewModel viewModel) where TViewModel : DialogViewModelBase
+		{
+			return FindPage(viewModel);
+		}
+
+		#endregion
+
+		#region Открытие
+
+		public IPage<TViewModel> OpenViewModel<TViewModel>(DialogViewModelBase master, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase
+		{
+			var types = new Type[] { };
+			var values = new object[] { };
+			return OpenViewModelTypedArgs<TViewModel>(master, types, values, options);
+		}
+
+		public IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1>(DialogViewModelBase master, TCtorArg1 arg1, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase
+		{
+			var types = new Type[] { typeof(TCtorArg1) };
+			var values = new object[] { arg1 };
+			return OpenViewModelTypedArgs<TViewModel>(master, types, values, options);
+		}
+
+		public IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1, TCtorArg2>(DialogViewModelBase master, TCtorArg1 arg1, TCtorArg1 arg2, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase
+		{
+			var types = new Type[] { typeof(TCtorArg1), typeof(TCtorArg2) };
+			var values = new object[] { arg1, arg2 };
+			return OpenViewModelTypedArgs<TViewModel>(master, types, values, options);
+		}
+
+		public IPage<TViewModel> OpenViewModel<TViewModel, TCtorArg1, TCtorArg2, TCtorArg3>(DialogViewModelBase master, TCtorArg1 arg1, TCtorArg1 arg2, TCtorArg1 arg3, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase
+		{
+			var types = new Type[] { typeof(TCtorArg1), typeof(TCtorArg2), typeof(TCtorArg3) };
+			var values = new object[] { arg1, arg2, arg3 };
+			return OpenViewModelTypedArgs<TViewModel>(master, types, values, options);
+		}
+
+		public IPage<TViewModel> OpenViewModelTypedArgs<TViewModel>(DialogViewModelBase master, Type[] ctorTypes, object[] ctorValues, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase
+		{
+			return (IPage<TViewModel>)OpenViewModelInternal(
+				FindPage(master), options,
+				() => hashGenerator.GetHash<TViewModel>(master, ctorTypes, ctorValues),
+				(hash) => viewModelsFactory.CreateViewModelTypedArgs<TViewModel>(master, ctorTypes, ctorValues, hash)
+			);
+		}
+
+		public IPage<TViewModel> OpenViewModelNamedArgs<TViewModel>(DialogViewModelBase master, IDictionary<string, object> ctorArgs, OpenPageOptions options = OpenPageOptions.None) where TViewModel : DialogViewModelBase
+		{
+			return (IPage<TViewModel>)OpenViewModelInternal(
+				FindPage(master), options,
+				() => hashGenerator.GetHashNamedArgs<TViewModel>(master, ctorArgs),
+				(hash) => viewModelsFactory.CreateViewModelNamedArgs<TViewModel>(master, ctorArgs, hash)
+			);
+		}
+
+		#region Внутренне
+
+		protected IPage OpenViewModelInternal(IPage masterPage, OpenPageOptions options, Func<string> makeHash, Func<string, IPage> makePage)
+		{
+			string hash = null;
+			if(!options.HasFlag(OpenPageOptions.IgnoreHash))
+				hash = makeHash();
+
+			IPage openPage = null;
+
+			if(options.HasFlag(OpenPageOptions.AsSlave)) {
+				if(masterPage == null)
+					throw new InvalidOperationException($"Отсутствует главная страница для добавляемой подчиненой страницы.");
+
+				if(hash != null)
+					openPage = masterPage.SlavePagesAll.Select(x => x.SlavePage).FirstOrDefault(x => x.PageHash == hash);
+				if(openPage != null)
+					SwitchOn(openPage);
+				else {
+					openPage = makePage(hash);
+					(masterPage as IPageInternal).AddSlavePage(openPage);
+					OpenSlavePage(masterPage, openPage);
+				}
+			} else {
+				if(hash != null)
+					openPage = IndependentPages.FirstOrDefault(x => x.PageHash == hash);
+				if(openPage != null)
+					SwitchOn(openPage);
+				else {
+					openPage = makePage(hash);
+					OpenPage(masterPage, openPage);
+				}
+			}
+			return openPage;
+		}
+
+		protected void ClosePage(IPage page)
+		{
+			var closedPagePair = SlavePages.FirstOrDefault(x => x.SlavePage == page);
+			if (closedPagePair != null)
+				(closedPagePair.MasterPage as IPageInternal).RemoveSlavePage(closedPagePair.SlavePage);
+			var pageToRemove = pages.FirstOrDefault(x => x == page);
+			if (pageToRemove != null) {
+				pages.Remove(pageToRemove);
+				(pageToRemove as IPageInternal).OnClosed();
+			}
+			else {
+				var childPair = ChildPages.FirstOrDefault(x => x.ChildPage == page);
+				if (childPair != null) {
+					(childPair.ParentPage as IPageInternal).RemoveChildPage(childPair.ChildPage);
+					(childPair.ChildPage as IPageInternal).OnClosed();
+				}
+			}
+
+			if (page.ViewModel is IDisposable pd)
+				pd.Dispose();
+		}
+		#endregion
+
+		#endregion
+
+		#region Абстрактные методы
+		public abstract void SwitchOn(IPage page);
+
+		protected abstract void OpenSlavePage(IPage masterPage, IPage page);
+		protected abstract void OpenPage(IPage masterPage, IPage page);
+		#endregion
+	}
+}

--- a/QS.Project/Navigation/Page.cs
+++ b/QS.Project/Navigation/Page.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using QS.Tdi;
@@ -15,7 +15,7 @@ namespace QS.Navigation
 			PageHash = hash;
 		}
 
-		public new TViewModel ViewModel { get; private set; }
+		public TViewModel ViewModel { get; private set; }
 
 		public ITdiTab TdiTab => ViewModel as ITdiTab;
 

--- a/QS.Project/Navigation/Page.cs
+++ b/QS.Project/Navigation/Page.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using QS.Tdi;
@@ -7,7 +7,7 @@ using QS.ViewModels;
 namespace QS.Navigation
 {
 	public class Page<TViewModel> : PageBase, IPage, IPage<TViewModel>, ITdiPage
-		where TViewModel : ViewModelBase
+		where TViewModel : DialogViewModelBase
 	{
 		public Page(TViewModel viewModel, string hash)
 		{
@@ -19,6 +19,6 @@ namespace QS.Navigation
 
 		public ITdiTab TdiTab => ViewModel as ITdiTab;
 
-		ViewModelBase IPage.ViewModel => ViewModel;
+		DialogViewModelBase IPage.ViewModel => ViewModel;
 	}
 }

--- a/QS.Project/Navigation/PageBase.cs
+++ b/QS.Project/Navigation/PageBase.cs
@@ -43,7 +43,7 @@ namespace QS.Navigation
 
 		public IEnumerable<IPage> ChildPages => childPages;
 
-		ViewModelBase IPage.ViewModel => null;
+		DialogViewModelBase IPage.ViewModel => null;
 
 		#region Приватное
 

--- a/QS.Project/Project.Journal/EntityJournalViewModelBase.cs
+++ b/QS.Project/Project.Journal/EntityJournalViewModelBase.cs
@@ -18,7 +18,7 @@ namespace QS.Project.Journal
 {
 	public abstract class EntityJournalViewModelBase<TEntity, TEntityViewModel, TNode> : JournalViewModelBase
 		where TEntity : class, IDomainObject
-		where TEntityViewModel : ViewModelBase
+		where TEntityViewModel : DialogViewModelBase
 		where TNode : class
 	{
 		#region Обязательные зависимости

--- a/QS.Project/Project.Journal/EntityJournalViewModelBase.cs
+++ b/QS.Project/Project.Journal/EntityJournalViewModelBase.cs
@@ -24,7 +24,6 @@ namespace QS.Project.Journal
 		#region Обязательные зависимости
 		#endregion
 		#region Опциональные зависимости
-		protected INavigationManager NavigationManager; //Необязательный так как передопределнные методы открытия диалогов могут быть заменены на неиспользуемые менеджер навигации.
 		protected IDeleteEntityService DeleteEntityService; //Опционально аналогично предыдущиему сервису.
 		public ICurrentPermissionService CurrentPermissionService { get; set; }
 		#endregion
@@ -32,7 +31,7 @@ namespace QS.Project.Journal
 		protected EntityJournalViewModelBase(
 			IUnitOfWorkFactory unitOfWorkFactory,
 			IInteractiveService interactiveService,
-			INavigationManager navigationManager = null,
+			INavigationManager navigationManager,
 			IDeleteEntityService deleteEntityService = null,
 			ICurrentPermissionService currentPermissionService = null
 			) : base(unitOfWorkFactory, interactiveService)

--- a/QS.Project/QS.Project.csproj
+++ b/QS.Project/QS.Project.csproj
@@ -313,6 +313,7 @@
     <Compile Include="ViewModels\Control\EEVM\IEntityAutocompleteSelector.cs" />
     <Compile Include="ViewModels\Control\EEVM\JournalViewModelAutocompleteSelector.cs" />
     <Compile Include="ViewModels\DialogViewModelBase.cs" />
+    <Compile Include="Navigation\NavigationManagerBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Project.Domain\" />

--- a/QS.Project/QS.Project.csproj
+++ b/QS.Project/QS.Project.csproj
@@ -312,6 +312,7 @@
     <Compile Include="ViewModels\Control\EEVM\JournalViewModelSelector.cs" />
     <Compile Include="ViewModels\Control\EEVM\IEntityAutocompleteSelector.cs" />
     <Compile Include="ViewModels\Control\EEVM\JournalViewModelAutocompleteSelector.cs" />
+    <Compile Include="ViewModels\DialogViewModelBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Project.Domain\" />

--- a/QS.Project/ViewModels/Control/EEVM/CommonEEVMBuilder.cs
+++ b/QS.Project/ViewModels/Control/EEVM/CommonEEVMBuilder.cs
@@ -45,7 +45,7 @@ namespace QS.ViewModels.Control.EEVM
 		}
 
 		public CommonEEVMBuilder<TBindedEntity, TEntity> UseViewModelDialog<TEntityViewModel>()
-			where TEntityViewModel : ViewModelBase
+			where TEntityViewModel : DialogViewModelBase
 		{
 			EntityDlgOpener = new EntityViewModelOpener<TEntityViewModel>(factory.NavigationManager, factory.DialogViewModel);
 			return this;

--- a/QS.Project/ViewModels/Control/EEVM/CommonEEVMBuilderFactory.cs
+++ b/QS.Project/ViewModels/Control/EEVM/CommonEEVMBuilderFactory.cs
@@ -12,7 +12,7 @@ namespace QS.ViewModels.Control.EEVM
 		where TBindedEntity: class, INotifyPropertyChanged
 	{
 		public TBindedEntity BindedEntity { get; set; }
-		public ViewModelBase DialogViewModel { get; set; }
+		public DialogViewModelBase DialogViewModel { get; set; }
 		public IUnitOfWork UnitOfWork { get; set; }
 		public INavigationManager NavigationManager { get; set; }
 
@@ -21,7 +21,7 @@ namespace QS.ViewModels.Control.EEVM
 		/// </summary>
 		public ILifetimeScope AutofacScope { get; set; }
 
-		public CommonEEVMBuilderFactory(ViewModelBase dialogViewModel, TBindedEntity source, IUnitOfWork unitOfWork, INavigationManager navigation)
+		public CommonEEVMBuilderFactory(DialogViewModelBase dialogViewModel, TBindedEntity source, IUnitOfWork unitOfWork, INavigationManager navigation)
 		{
 			BindedEntity = source;
 			DialogViewModel = dialogViewModel;

--- a/QS.Project/ViewModels/Control/EEVM/EntityViewModelOpener.cs
+++ b/QS.Project/ViewModels/Control/EEVM/EntityViewModelOpener.cs
@@ -5,12 +5,12 @@ using QS.Project.Domain;
 namespace QS.ViewModels.Control.EEVM
 {
 	public class EntityViewModelOpener<TEntityViewModel> : IEntityDlgOpener
-		where TEntityViewModel : ViewModelBase
+		where TEntityViewModel : DialogViewModelBase
 	{
 		private readonly INavigationManager navigationManager;
-		private readonly ViewModelBase masterViewModel;
+		private readonly DialogViewModelBase masterViewModel;
 
-		public EntityViewModelOpener(INavigationManager navigationManager, ViewModelBase masterViewModel = null)
+		public EntityViewModelOpener(INavigationManager navigationManager, DialogViewModelBase masterViewModel = null)
 		{
 			this.navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
 			this.masterViewModel = masterViewModel;

--- a/QS.Project/ViewModels/Control/EEVM/JournalViewModelSelector.cs
+++ b/QS.Project/ViewModels/Control/EEVM/JournalViewModelSelector.cs
@@ -15,7 +15,7 @@ namespace QS.ViewModels.Control.EEVM
 		private readonly INavigationManager navigationManager;
 		private readonly IUnitOfWork uow;
 		readonly ITdiTab parrentTab;
-		readonly ViewModelBase parrentViewModel;
+		readonly DialogViewModelBase parrentViewModel;
 
 		/// <summary>
 		/// Специальный конструктор для старых диалогов базирующихся ITdiTab
@@ -25,13 +25,13 @@ namespace QS.ViewModels.Control.EEVM
 		{
 			this.navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
 			this.uow = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
-			if (parrentTab is ViewModelBase viewModel)
+			if (parrentTab is DialogViewModelBase viewModel)
 				parrentViewModel = viewModel;
 			else
 				this.parrentTab = parrentTab ?? throw new ArgumentNullException(nameof(parrentTab)); ;
 		}
 
-		public JournalViewModelSelector(ViewModelBase parrentViewModel, IUnitOfWork unitOfWork, INavigationManager navigationManager)
+		public JournalViewModelSelector(DialogViewModelBase parrentViewModel, IUnitOfWork unitOfWork, INavigationManager navigationManager)
 		{
 			this.navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
 			this.uow = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));

--- a/QS.Project/ViewModels/DialogViewModelBase.cs
+++ b/QS.Project/ViewModels/DialogViewModelBase.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using QS.Services;
+
+namespace QS.ViewModels
+{
+	/// <summary>
+	/// Базовый класс для всех ViewModel представляющих из себя диалоги. Это либо вкладки, либо окна в интерфейсе. 
+	/// Которые пользователь откывает для совершения каких-то отдельных действий.
+	/// Внутри кода, такие диалоги открываются через INavigationManager
+	/// </summary>
+	public class DialogViewModelBase : ViewModelBase
+	{
+
+		public DialogViewModelBase(IInteractiveService interactiveService) : base(interactiveService)
+		{
+		}
+
+		private string title;
+		public virtual string Title {
+			get => title;
+			set => SetField(ref title, value);
+		}
+	}
+}

--- a/QS.Project/ViewModels/DialogViewModelBase.cs
+++ b/QS.Project/ViewModels/DialogViewModelBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using QS.Navigation;
 using QS.Services;
 
 namespace QS.ViewModels
@@ -10,6 +11,8 @@ namespace QS.ViewModels
 	/// </summary>
 	public class DialogViewModelBase : ViewModelBase
 	{
+		//FIXME Когда выпилим ViewModel с TDI, добавить заполение свойства через конструктор;
+		public INavigationManager NavigationManager { get; set; }
 
 		public DialogViewModelBase(IInteractiveService interactiveService) : base(interactiveService)
 		{
@@ -19,6 +22,17 @@ namespace QS.ViewModels
 		public virtual string Title {
 			get => title;
 			set => SetField(ref title, value);
+		}
+
+		public virtual void Close(bool askClose)
+		{
+			var page = NavigationManager?.FindPage(this);
+			if(page != null) {
+				if(askClose)
+					NavigationManager.AskClosePage(page);
+				else
+					NavigationManager.ForceClosePage(page);
+			}
 		}
 	}
 }

--- a/QS.Project/ViewModels/TabViewModelBase.cs
+++ b/QS.Project/ViewModels/TabViewModelBase.cs
@@ -91,12 +91,14 @@ namespace QS.ViewModels
 			OnPropertyChanged(nameof(Title));
 		}
 
-		public virtual void Close(bool askSave)
+		public override void Close(bool askSave)
 		{
 			if(askSave)
 				TabParent?.AskToCloseTab(this);
 			else
 				TabParent?.ForceCloseTab(this);
+
+			base.Close(askSave);
 		}
 
 		public void OnTabClosed()

--- a/QS.Project/ViewModels/TabViewModelBase.cs
+++ b/QS.Project/ViewModels/TabViewModelBase.cs
@@ -6,11 +6,13 @@ using QS.Tdi;
 
 namespace QS.ViewModels
 {
-	public abstract class TabViewModelBase : ViewModelBase, ITdiTab, IDisposable
+	public abstract class TabViewModelBase : DialogViewModelBase, ITdiTab, IDisposable
 	{
 		protected TabViewModelBase(IInteractiveService interactiveService) : base(interactiveService)
 		{
 		}
+
+		public override string Title { get => TabName; set => TabName = value; }
 
 		#region ITdiTab implementation
 
@@ -86,6 +88,7 @@ namespace QS.ViewModels
 		protected virtual void OnTabNameChanged()
 		{
 			TabNameChanged?.Invoke(this, new TdiTabNameChangedEventArgs(TabName));
+			OnPropertyChanged(nameof(Title));
 		}
 
 		public virtual void Close(bool askSave)

--- a/QSOrmProject/ViewModels/Control/EEVM/LegacyEEVMBuilderFactory.cs
+++ b/QSOrmProject/ViewModels/Control/EEVM/LegacyEEVMBuilderFactory.cs
@@ -13,7 +13,7 @@ namespace QS.ViewModels.Control.EEVM
 	{
 		public readonly ITdiTab DialogTab;
 
-		public LegacyEEVMBuilderFactory(ViewModelBase dialogViewModel, ITdiTab dialogTab, TBindedEntity source, IUnitOfWork unitOfWork, INavigationManager navigation) : base(dialogViewModel, source, unitOfWork, navigation)
+		public LegacyEEVMBuilderFactory(DialogViewModelBase dialogViewModel, ITdiTab dialogTab, TBindedEntity source, IUnitOfWork unitOfWork, INavigationManager navigation) : base(dialogViewModel, source, unitOfWork, navigation)
 		{
 			DialogTab = dialogTab;
 		}


### PR DESCRIPTION
Этот менеджер навигации, совсем не использует вкладки и TDI. А использует для открытия ViewModel-ей отдельные окна Gtk.
Мне он понадобился для плавного перевода старых проектов на новый интерфейс с ViewModel, минуя использование TDI как такового. Вообще без использования и подключения к проекту библиотеки OrmProject.
Хороший тест концепции viewModel... по отвязыванию от Tdi.