### PR TITLE
Переделана установка ширины выбора даты с внутреннего виджета на сам диалог

### DIFF
--- a/QS.Project.Gtk/Widgets.GtkUI/DatePicker.cs
+++ b/QS.Project.Gtk/Widgets.GtkUI/DatePicker.cs
@@ -169,9 +169,9 @@ namespace QS.Widgets.GtkUI
 					CalendarDisplayOptions.ShowWeekNumbers;
 			SelectDate.DaySelectedDoubleClick += OnCalendarDaySelectedDoubleClick;
 			SelectDate.Date = date ?? DateTime.Now.Date;
-			SelectDate.WidthRequest = DefaultWidthRequest;
 
 			editDate.VBox.Add(SelectDate);
+			editDate.WidthRequest = DefaultWidthRequest;
 			editDate.ShowAll();
 			int response = editDate.Run ();
 			if(response == (int)ResponseType.Ok)

--- a/QS.Project.Gtk/Widgets.GtkUI/DateRangePicker.cs
+++ b/QS.Project.Gtk/Widgets.GtkUI/DateRangePicker.cs
@@ -179,7 +179,6 @@ namespace QS.Widgets.GtkUI
 			StartDateCalendar.MonthChanged += StartDateCalendar_MonthChanged;
 			StartDateCalendar.Day = 0;
 			StartDateCalendar_MonthChanged(null, null);
-			StartDateCalendar.WidthRequest = DefaultWidthRequest;
 
 			EndDateCalendar = new Calendar ();
 			EndDateCalendar.DisplayOptions = DisplayOptions;
@@ -187,7 +186,6 @@ namespace QS.Widgets.GtkUI
 			EndDateCalendar.MonthChanged += EndDateCalendar_MonthChanged;
 			EndDateCalendar.Day = 0;
 			EndDateCalendar_MonthChanged(null, null);
-			EndDateCalendar.WidthRequest = DefaultWidthRequest;
 
 			StartDateEntry = new DatePicker();
 			StartDateEntry.DateChanged += StartDateEntry_DateChanged;
@@ -204,6 +202,7 @@ namespace QS.Widgets.GtkUI
 			hbox.Add(endVbox);
 
 			selectDate.VBox.Add (hbox);
+			selectDate.WidthRequest = DefaultWidthRequest;
 			selectDate.ShowAll ();
 
 			StartDateEntry.HideCalendarButton = true;


### PR DESCRIPTION
После нескольких успешных билдов, почему начал падать виджет выбора одиночной даты. Поэтому переделано на установку ширины всего диалога вместо внутреннего виджета