### PR TITLE
Исправил ошибку с транзакцией в UnitOfWorkChild

### DIFF
--- a/QS.Project/DomainModel/UoW/UnitOfWorkBase.cs
+++ b/QS.Project/DomainModel/UoW/UnitOfWorkBase.cs
@@ -27,7 +27,7 @@ namespace QS.DomainModel.UoW
 
 		public event EventHandler<EntityUpdatedEventArgs> SessionScopeEntitySaved;
 
-		protected ITransaction transaction;
+		protected virtual ITransaction transaction { get; set; }
 
 		protected ISession session;
 
@@ -176,7 +176,7 @@ namespace QS.DomainModel.UoW
 			Session.Delete(entity);
 		}
 
-		protected void OpenTransaction()
+		internal virtual void OpenTransaction()
 		{
 			if(transaction == null) {
 				transaction = Session.BeginTransaction();


### PR DESCRIPTION
UnitOfWorkChild должен использовать транзакцию из parentUoW. Для этого ему нужно дать использовать OpenTransaction из parentUoW. В будущем необходимо полностью отказаться от изпользования Child