### PR TITLE
Исправлена работа Менеджера навигации на обычных диалогах Gtk

### DIFF
--- a/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Gtk;
 using QS.Dialog;
 using QS.Views.Resolve;
@@ -55,9 +56,19 @@ namespace QS.Navigation
 			gtkPage.GtkDialog.VBox.Add(gtkPage.GtkView);
 			gtkPage.GtkView.Show();
 			gtkPage.GtkDialog.Show();
-			gtkPage.GtkDialog.Run();
-			ClosePage(page);
-			gtkPage.GtkDialog.Destroy();
+			gtkPage.GtkDialog.DeleteEvent += GtkDialog_DeleteEvent;
+			gtkPage.ViewModel.PropertyChanged += (sender, e) => gtkPage.GtkDialog.Title = gtkPage.ViewModel.Title;
+		}
+
+		public IPage FindPage(Gdk.Window window)
+		{
+			return AllPages.Cast<IGtkWindowPage>().FirstOrDefault(x => x.GtkDialog.GdkWindow == window);
+		}
+
+		void GtkDialog_DeleteEvent(object o, DeleteEventArgs args)
+		{
+			var page = FindPage(args.Event.Window) ?? throw new InvalidOperationException("Закрыто окно которое не зарегистрировано как страницы в навигаторе");
+			ForceClosePage(page);
 		}
 	}
 }

--- a/QS.Project/Project.Journal/EntityJournalViewModelBase.cs
+++ b/QS.Project/Project.Journal/EntityJournalViewModelBase.cs
@@ -24,7 +24,7 @@ namespace QS.Project.Journal
 		#region Обязательные зависимости
 		#endregion
 		#region Опциональные зависимости
-		protected IDeleteEntityService DeleteEntityService; //Опционально аналогично предыдущиему сервису.
+		protected IDeleteEntityService DeleteEntityService;
 		public ICurrentPermissionService CurrentPermissionService { get; set; }
 		#endregion
 


### PR DESCRIPTION
- При открытии диалога не вызываем Run и вообще работает без него. Так как он загодняет программу в локальный цикл ожидания ответа диалога. А у нас там ViewModel которые расчитаны на другую работу.
- Соответсвено реализовано более корректное закрытие окон.
- Исправлена проблема с обновление заголовка окна.