### PR TITLE
Исправлено заполнение поля SelectedConnection при переключении базы

### DIFF
--- a/QS.Project/ViewModels/Dialog/ModalDialogViewModelBase.cs
+++ b/QS.Project/ViewModels/Dialog/ModalDialogViewModelBase.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using QS.Navigation;
+
+namespace QS.ViewModels.Dialog
+{
+	public class ModalDialogViewModelBase : DialogViewModelBase
+	{
+		public ModalDialogViewModelBase(INavigationManager navigation) : base(navigation)
+		{
+		}
+	}
+}


### PR DESCRIPTION
Это поле в некоторых проектах используется для отображения названия базы в заголовке программы.
При этом получалось что там всегда отображается только название которое было при старте.