### PR TITLE
Исправлено заполнение поля SelectedConnection при переключении базы 

### DIFF
--- a/QSProjectsLib/Login.cs
+++ b/QSProjectsLib/Login.cs
@@ -325,6 +325,7 @@ namespace QSProjectsLib
 			server = Selected.Server;
 			entryUser.Text = Selected.UserName;
 			BaseName = Selected.BaseName;
+			SelectedConnection = Selected.ConnectionName;
 			entryPassword.GrabFocus();
 			if (ApplicationDemoServer == null)
 				return;


### PR DESCRIPTION
Это поле в некоторых проектах используется для отображения названия базы в заголовке программы.
При этом получалось что там всегда отображается только название которое было при старте.

