### PR TITLE
Пометил интерфейс как устаревший.

### DIFF
--- a/QS.Project.Gtk/RepresentationModel.GtkUI/IRepresentationModel.cs
+++ b/QS.Project.Gtk/RepresentationModel.GtkUI/IRepresentationModel.cs
@@ -6,6 +6,7 @@ using QS.DomainModel.UoW;
 
 namespace QS.RepresentationModel.GtkUI
 {
+	[Obsolete("Осталось только для ВОДОВОЗА. Данный интрефейс и классы с нимми связанные должны быть удалены или перенесены в OrmProject.")]
 	public interface IRepresentationModel
 	{
 		Type NodeType { get;}
@@ -40,11 +41,13 @@ namespace QS.RepresentationModel.GtkUI
 		void Destroy();
 	}
 
+	[Obsolete("Осталось только для ВОДОВОЗА. Данный интрефейс и классы с нимми связанные должны быть удалены или перенесены в OrmProject.")]
 	public interface IRepresentationModelWithParent
 	{
 		object GetParent { get;}
 	}
 
+	[Obsolete("Осталось только для ВОДОВОЗА. Данный интрефейс и классы с нимми связанные должны быть удалены или перенесены в OrmProject.")]
 	public interface INodeWithEntryFastSelect
 	{
 		string EntityTitle { get; }


### PR DESCRIPTION
Он дублирует аналогичный в из OrmProject. И я уже задолбался ловить ошибки в AutoFac, потому видимо подключаю пространства имен на автомате, первое что попалось, и постоянно выбирается не тот интерфейс.
При этом он реально используется только в части диалогов водовоза. И думаю должен быть удален в будущем.