### PR TITLE
Поиск в журнале перенесен в базовый класс журнала.

### DIFF
--- a/QS.Project/Project.Journal/EntitiesJournalViewModelBase.cs
+++ b/QS.Project/Project.Journal/EntitiesJournalViewModelBase.cs
@@ -47,13 +47,6 @@ namespace QS.Project.Journal
 			this.commonServices = commonServices ?? throw new ArgumentNullException(nameof(commonServices));
 			UseSlider = true;
 			EntityConfigs = new Dictionary<Type, JournalEntityConfig<TNode>>();
-			Search.OnSearch += Search_OnSearch;
-			searchHelper = new SearchHelper(Search);
-		}
-
-		void Search_OnSearch(object sender, EventArgs e)
-		{
-			Refresh();
 		}
 
 		void FilterViewModel_OnFiltered(object sender, EventArgs e)
@@ -127,22 +120,6 @@ namespace QS.Project.Journal
 		}
 
 		#endregion Ordering
-
-		#region Search
-
-		private readonly SearchHelper searchHelper;
-
-		protected ICriterion GetSearchCriterion(params Expression<Func<object>>[] aliasPropertiesExpr)
-		{
-			return searchHelper.GetSearchCriterion(aliasPropertiesExpr);
-		}
-
-		protected ICriterion GetSearchCriterion<TEntity>(params Expression<Func<TEntity, object>>[] propertiesExpr)
-		{
-			return searchHelper.GetSearchCriterion(propertiesExpr);
-		}
-
-		#endregion Search
 
 		#region Entity load configuration
 

--- a/QS.Project/Project.Journal/EntityJournalViewModelBase.cs
+++ b/QS.Project/Project.Journal/EntityJournalViewModelBase.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Linq;
-using System.Linq.Expressions;
 using NHibernate;
-using NHibernate.Criterion;
 using QS.DomainModel.Entity;
 using QS.DomainModel.UoW;
 using QS.Navigation;
 using QS.Project.Domain;
 using QS.Project.Journal.DataLoader;
-using QS.Project.Journal.Search;
 using QS.Project.Services;
 using QS.Services;
 using QS.Utilities.Text;
@@ -52,10 +49,6 @@ namespace QS.Project.Journal
 			var names = typeof(TEntity).GetSubjectNames();
 			if(!String.IsNullOrEmpty(names?.NominativePlural))
 				TabName = names.NominativePlural.StringToTitleCase();
-
-			//Поиск
-			Search.OnSearch += Search_OnSearch;
-			searchHelper = new SearchHelper(Search);
 
 			UpdateOnChanges(typeof(TEntity));
 		}
@@ -116,26 +109,5 @@ namespace QS.Project.Journal
 			foreach(var node in nodes)
 				DeleteEntityService.DeleteEntity<TEntity>(DomainHelper.GetId(node));
 		}
-
-		#region Поиск
-
-		void Search_OnSearch(object sender, EventArgs e)
-		{
-			Refresh();
-		}
-
-		private readonly SearchHelper searchHelper;
-
-		protected ICriterion GetSearchCriterion(params Expression<Func<object>>[] aliasPropertiesExpr)
-		{
-			return searchHelper.GetSearchCriterion(aliasPropertiesExpr);
-		}
-
-		protected ICriterion GetSearchCriterion<TRootEntity>(params Expression<Func<TRootEntity, object>>[] propertiesExpr)
-		{
-			return searchHelper.GetSearchCriterion(propertiesExpr);
-		}
-
-		#endregion
 	}
 }

--- a/QS.Project/Project.Journal/JournalViewModelBase.cs
+++ b/QS.Project/Project.Journal/JournalViewModelBase.cs
@@ -2,12 +2,15 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Autofac;
+using NHibernate.Criterion;
 using NLog;
 using QS.DomainModel.NotifyChange;
 using QS.DomainModel.UoW;
 using QS.Navigation;
 using QS.Project.Journal.DataLoader;
+using QS.Project.Journal.Search;
 using QS.Project.Search;
 using QS.Services;
 using QS.Tdi;
@@ -76,7 +79,10 @@ namespace QS.Project.Journal
 			NodeActionsList = new List<IJournalAction>();
 			PopupActionsList = new List<IJournalAction>();
 
+			//Поиск
 			Search = new SearchViewModel();
+			Search.OnSearch += Search_OnSearch;
+			searchHelper = new SearchHelper(Search);
 
 			UseSlider = false;
 		}
@@ -130,5 +136,26 @@ namespace QS.Project.Journal
 			NotifyConfiguration.Instance.UnsubscribeAll(this);
 			base.Dispose();
 		}
+
+		#region Поиск
+
+		void Search_OnSearch(object sender, EventArgs e)
+		{
+			Refresh();
+		}
+
+		private readonly SearchHelper searchHelper;
+
+		protected ICriterion GetSearchCriterion(params Expression<Func<object>>[] aliasPropertiesExpr)
+		{
+			return searchHelper.GetSearchCriterion(aliasPropertiesExpr);
+		}
+
+		protected ICriterion GetSearchCriterion<TRootEntity>(params Expression<Func<TRootEntity, object>>[] propertiesExpr)
+		{
+			return searchHelper.GetSearchCriterion(propertiesExpr);
+		}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
Он нужен во всех журналах, даже реализованных на JournalViewModelBase при этом в текущей реализации его все равно ни на что другое не заменить.