### PR TITLE
Реализовал другой вариант фильтра для журнала. 

### DIFF
--- a/QS.Project.Gtk/Dialog.GtkUI/DialogHelper.cs
+++ b/QS.Project.Gtk/Dialog.GtkUI/DialogHelper.cs
@@ -9,11 +9,7 @@ namespace QS.Dialog.Gtk
 {
 	public static class DialogHelper
 	{
-		static DialogHelper()
-		{
-			FilterWidgetResolver = new DefaultFilterWidgetResolver();
-		}
-
+		[Obsolete("Оставлено только для ВОДОВОЗА. В других проектах не используется так как откзывается от антипатерна ServiceLocation.")]
 		public static IFilterWidgetResolver FilterWidgetResolver { get; set; }
 
 		public static IEntityDialog FindParentEntityDialog(Widget child)

--- a/QS.Project.Gtk/Dialog.GtkUI/IFilterWidgetResolver.cs
+++ b/QS.Project.Gtk/Dialog.GtkUI/IFilterWidgetResolver.cs
@@ -2,36 +2,10 @@
 using Gtk;
 namespace QS.Dialog.GtkUI
 {
+	[Obsolete("Используется только в ВОДОВОЗЕ. Удалить когда в водовозе не останется классов.")]
 	public interface IFilterWidgetResolver
 	{
 		Widget Resolve(RepresentationModel.IJournalFilter filter);
 		Widget Resolve(Project.Journal.IJournalFilter filter);
-	}
-
-	public class DefaultFilterWidgetResolver : IFilterWidgetResolver
-	{
-		public Widget Resolve(RepresentationModel.IJournalFilter filter)
-		{
-			if(filter == null) {
-				return null;
-			}
-
-			if(filter is Widget) {
-				return (Widget)filter;
-			}
-			throw new InvalidCastException($"Ошибка приведения типа {nameof(RepresentationModel.IJournalFilter)} к типу {nameof(Widget)}.");
-		}
-
-		public Widget Resolve(Project.Journal.IJournalFilter filter)
-		{
-			if(filter == null) {
-				return null;
-			}
-
-			if(filter is Widget) {
-				return (Widget)filter;
-			}
-			throw new InvalidCastException($"Ошибка приведения типа {nameof(RepresentationModel.IJournalFilter)} к типу {nameof(Widget)}.");
-		}
 	}
 }

--- a/QS.Project.Gtk/Journal.GtkUI/JournalView.cs
+++ b/QS.Project.Gtk/Journal.GtkUI/JournalView.cs
@@ -13,7 +13,9 @@ using QS.Project.Search;
 using QS.Project.Search.GtkUI;
 using QS.Utilities;
 using QS.Utilities.Text;
+using QS.ViewModels;
 using QS.Views.GtkUI;
+using QS.Views.Resolve;
 using QSWidgetLib;
 
 namespace QS.Journal.GtkUI
@@ -63,12 +65,25 @@ namespace QS.Journal.GtkUI
 			}
 			ConfigureActions();
 
-			if(ViewModel.Filter != null) {
-				Widget filterWidget = DialogHelper.FilterWidgetResolver.Resolve(ViewModel.Filter);
+			//FIXME Этот код только для водовоза
+			var filterProp = ViewModel.GetType().GetProperty("Filter");
+			if(DialogHelper.FilterWidgetResolver != null && filterProp != null && filterProp.PropertyType == typeof(IJournalFilter)) {
+				var filter = filterProp.GetValue(ViewModel) as IJournalFilter;
+				Widget filterWidget = filterWidget = DialogHelper.FilterWidgetResolver.Resolve(filter);
 				hboxFilter.Add(filterWidget);
 				filterWidget.Show();
 				checkShowFilter.Visible = true;
-				checkShowFilter.Active = hboxFilter.Visible = !ViewModel.Filter.HidenByDefault;
+				checkShowFilter.Active = hboxFilter.Visible = !filter.HidenByDefault;
+			}
+
+			if(ViewModel.JournalFilter is ViewModelBase filterViewModel) {
+				var viewResolver = ViewModel.AutofacScope.Resolve<IGtkViewResolver>();
+				Widget filterView = viewResolver.Resolve(filterViewModel);
+
+				hboxFilter.Add(filterView);
+				filterView.Show();
+				checkShowFilter.Visible = true;
+				checkShowFilter.Active = hboxFilter.Visible = !ViewModel.JournalFilter.HidenByDefault;
 			}
 
 			Widget searchView = ViewModel.AutofacScope != null ? ResolutionExtensions.ResolveOptionalNamed<Widget>(ViewModel.AutofacScope, "GtkJournalSearchView", new TypedParameter(typeof(SearchViewModel), ViewModel.Search)) : null;

--- a/QS.Project.Gtk/Project.Dialogs.GtkUI/RepresentationJournalDialog.cs
+++ b/QS.Project.Gtk/Project.Dialogs.GtkUI/RepresentationJournalDialog.cs
@@ -14,6 +14,7 @@ using QS.Utilities.Text;
 
 namespace QS.Project.Dialogs.GtkUI
 {
+	[Obsolete("Используется только в ВОДОВОЗЕ. Удалить, когда удалите из водовоза.")]
 	public partial class RepresentationJournalDialog : SingleUowTabBase, IJournalDialog
 	{
         private static Logger logger = LogManager.GetCurrentClassLogger ();

--- a/QS.Project/DomainModel/Entity/PropertyChangedBase.cs
+++ b/QS.Project/DomainModel/Entity/PropertyChangedBase.cs
@@ -10,22 +10,21 @@ namespace QS.DomainModel.Entity
 	{
 		public virtual void FirePropertyChanged ()
 		{
-			if (PropertyChanged != null)
-				PropertyChanged.Invoke (null, null);
+			OnPropertyChanged(null);
 		}
 
 		public virtual event PropertyChangedEventHandler PropertyChanged;
 
-		protected void OnPropertyChanged ([CallerMemberName]string propertyName = "")
+		protected virtual void OnPropertyChanged ([CallerMemberName]string propertyName = "")
 		{
-			PropertyChangedEventHandler handler = PropertyChanged;
-			if (handler != null) {
-				var att = this.GetType ().GetProperty (propertyName).GetCustomAttributes (typeof(PropertyChangedAlsoAttribute), true);
-				handler (this, new PropertyChangedEventArgs (propertyName));
-				if(att.Length > 0)
-				{
-					foreach(string propName in (att[0] as PropertyChangedAlsoAttribute).PropertiesNames)
-						handler (this, new PropertyChangedEventArgs (propName));
+			if (PropertyChanged != null) {
+				PropertyChanged(this, new PropertyChangedEventArgs (propertyName));
+				if(!String.IsNullOrWhiteSpace(propertyName)) {
+					var att = this.GetType().GetProperty(propertyName).GetCustomAttributes(typeof(PropertyChangedAlsoAttribute), true);
+					if(att.Length > 0) {
+						foreach(string propName in (att[0] as PropertyChangedAlsoAttribute).PropertiesNames)
+							PropertyChanged(this, new PropertyChangedEventArgs(propName));
+					}
 				}
 			}
 		}

--- a/QS.Project/Project.Journal/EntitiesJournalViewModelBase.cs
+++ b/QS.Project/Project.Journal/EntitiesJournalViewModelBase.cs
@@ -2,16 +2,13 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Linq.Expressions;
 using NHibernate;
-using NHibernate.Criterion;
 using NHibernate.Util;
 using QS.Deletion;
 using QS.DomainModel.Entity;
 using QS.DomainModel.UoW;
 using QS.Navigation;
 using QS.Project.Journal.DataLoader;
-using QS.Project.Journal.Search;
 using QS.Project.Services;
 using QS.Services;
 using QS.Tdi;
@@ -28,7 +25,7 @@ namespace QS.Project.Journal
 		protected Dictionary<Type, JournalEntityConfig<TNode>> EntityConfigs { get; private set; }
 
 		private IJournalFilter filter;
-		public override IJournalFilter Filter {
+		public IJournalFilter Filter {
 			get => filter;
 			protected set {
 				if(filter != null)

--- a/QS.Project/Project.Journal/IJournalFilterViewModel.cs
+++ b/QS.Project/Project.Journal/IJournalFilterViewModel.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace QS.Project.Journal
+{
+	public interface IJournalFilterViewModel : INotifyPropertyChanged
+	{
+		bool HidenByDefault { get; set; }
+	}
+}

--- a/QS.Project/Project.Journal/JournalFilterViewModelBase.cs
+++ b/QS.Project/Project.Journal/JournalFilterViewModelBase.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using QS.DomainModel.UoW;
+using QS.ViewModels;
+
+namespace QS.Project.Journal
+{
+	public class JournalFilterViewModelBase<TFilter> : ViewModelBase, IDisposable, IJournalFilterViewModel
+		where TFilter : JournalFilterViewModelBase<TFilter>
+	{
+		public bool HidenByDefault { get; set; }
+
+		private bool canNotify = true;
+
+		private IUnitOfWork uow;
+		private readonly IUnitOfWorkFactory unitOfWorkFactory;
+
+		public virtual IUnitOfWork UoW {
+			get {
+				if(uow == null)
+					uow = unitOfWorkFactory.CreateWithoutRoot();
+
+				return uow;
+			}
+		}
+
+		public JournalViewModelBase JournalViewModel { get; }
+
+		public JournalFilterViewModelBase(JournalViewModelBase journalViewModel, IUnitOfWorkFactory unitOfWorkFactory = null)
+		{
+			JournalViewModel = journalViewModel ?? throw new ArgumentNullException(nameof(journalViewModel));
+			this.unitOfWorkFactory = unitOfWorkFactory;
+		}
+
+		public void Update()
+		{
+			if(canNotify)
+				JournalViewModel.Refresh();
+		}
+
+		protected override void OnPropertyChanged([CallerMemberName] string propertyName = "")
+		{
+			base.OnPropertyChanged(propertyName);
+			Update();
+		}
+
+		/// <summary>
+		/// Для установки свойств фильтра без перезапуска фильтрации на каждом изменении
+		/// обновления журналов при каждом выставлении ограничения.
+		/// </summary>
+		/// <param name="setters">Лямбды ограничений</param>
+		public void SetAndRefilterAtOnce(params Action<TFilter>[] setters)
+		{
+			canNotify = false;
+			TFilter filter = this as TFilter;
+			foreach(var item in setters) {
+				item(filter);
+			}
+			canNotify = true;
+			Update();
+		}
+
+		public void Dispose() => UoW?.Dispose();
+	}
+}

--- a/QS.Project/Project.Journal/JournalViewModelBase.cs
+++ b/QS.Project/Project.Journal/JournalViewModelBase.cs
@@ -22,7 +22,7 @@ namespace QS.Project.Journal
 	{
 		private static Logger logger = LogManager.GetCurrentClassLogger();
 
-		public virtual IJournalFilter Filter { get; protected set; }
+		public virtual IJournalFilterViewModel JournalFilter { get; protected set; }
 
 		public virtual IJournalSearch Search { get; set; }
 

--- a/QS.Project/QS.Project.csproj
+++ b/QS.Project/QS.Project.csproj
@@ -337,6 +337,8 @@
     <Compile Include="ViewModels\Control\ESVM\EntitySearchViewModel.cs" /> 
     <Compile Include="ViewModels\Control\ESVM\IEntitySearchViewModel.cs" /> 
     <Compile Include="Navigation\ISlideableViewModel.cs" />
+    <Compile Include="Project.Journal\JournalFilterViewModelBase.cs" />
+    <Compile Include="Project.Journal\IJournalFilterViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Project.Domain\" />


### PR DESCRIPTION
В этой реализации:
- Упростил интерфейс фильтра. По сути он как таковой особо и не нужен. Оставил только свойство для автоскрытия фильтра. Так как фильтр для журнала, он сам может вызвать метод рефреш журнала. События и подписки в данной схеме усложняют код.
- Убрал из фильтра лишние методы, и изменил логику, на практике не вижу особой необходимости иметь в модели фильтра свойства с уведомлением об обновлении, но при этом не обновляющие сам фильтр. Поэтому логичнее чтобы по умолчанию все свойства вызывающие проперти чендж, вызывали обновления фильтра. И уж если вдруг понадобится, можно сделать исключения для каких нибудь. Это позволяет писать меньше кода, и не описывать дополнительно все свойства которые изменяют фильтр.
- Из основного журнала выпили старый интерфейс фильтра и оставил его только для водовоза.