### PR TITLE
Добавлен обходной путь проблемы с проверкой изменений через IsDirty

### DIFF
--- a/QS.Project/DomainModel/UoW/NhibernateExtend.cs
+++ b/QS.Project/DomainModel/UoW/NhibernateExtend.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Linq;
+using NHibernate;
+using NHibernate.Collection;
+using NHibernate.Engine;
+using NHibernate.Persister.Entity;
+using NHibernate.Proxy;
+
+namespace QS.DomainModel.UoW
+{
+	/// <summary>
+	/// Код решения частично взять https://nhibernate.info/doc/howto/various/finding-dirty-properties-in-nhibernate.html
+	/// и https://stackoverflow.com/a/35697565
+	/// </summary>
+	public static class NhibernateExtend
+	{
+		/// <summary>
+		/// Check whether a session is "dirty" without triggering a flush
+		/// </summary>
+		/// <param name="session"></param>
+		/// <returns>true if the session is "dirty", meaning that it will update the database when flushed</returns>
+		/// <remarks>
+		/// The rationale behind this is the need to determine if there's anything to flush to the database without actually
+		/// running through the Flush process.  The problem with a premature Flush is that one may want to collect changes
+		/// to persistent objects and only start a transaction later on to flush them.  I have this in a Winforms application
+		/// and this method allows me to notify the user whether he has made changes that need saving while not leaving a
+		/// transaction open while he works, which can cause locking issues.
+		/// <para>
+		/// Note that the check for dirty collections may give false positives, which is good enough for my purposes but 
+		/// coule be improved upon using calls to GetOrphans and other persistent-collection methods.</para>
+		/// </remarks>
+		public static bool IsDirtyNoFlush(this ISession session)
+		{
+			var pc = session.GetSessionImplementation().PersistenceContext;
+			if(pc.EntitiesByKey.Values.Any(o => IsDirtyEntity(session, o)))
+				return true;
+
+			return pc.CollectionEntries.Keys.Cast<IPersistentCollection>()
+				.Any(coll => coll.WasInitialized && coll.IsDirty);
+		}
+
+		public static Boolean IsDirtyEntity(this ISession session, Object entity)
+		{
+			ISessionImplementor sessionImpl = session.GetSessionImplementation();
+			IPersistenceContext persistenceContext = sessionImpl.PersistenceContext;
+			EntityEntry oldEntry = persistenceContext.GetEntry(entity);
+			string className = oldEntry.EntityName;
+			IEntityPersister persister = sessionImpl.Factory.GetEntityPersister(className);
+
+			if(oldEntry == null && entity is INHibernateProxy) {
+				INHibernateProxy proxy = entity as INHibernateProxy;
+				Object obj = sessionImpl.PersistenceContext.Unproxy(proxy);
+				oldEntry = sessionImpl.PersistenceContext.GetEntry(obj);
+			}
+
+			object[] oldState = oldEntry.LoadedState;
+			if(oldState == null) {
+				return false;
+			}
+
+			object[] currentState = persister.GetPropertyValues(entity);
+			int[] dirtyProps = oldState.Select((o, i) => (oldState[i] == currentState[i]) ? -1 : i).Where(x => x >= 0).ToArray();
+
+			return (dirtyProps != null && dirtyProps.Length > 0);
+		}
+	}
+}

--- a/QS.Project/DomainModel/UoW/UnitOfWork.cs
+++ b/QS.Project/DomainModel/UoW/UnitOfWork.cs
@@ -14,7 +14,7 @@ namespace QS.DomainModel.UoW
 				if(IsNew)
 					return true;
 				OpenTransaction();
-				return Session.IsDirty();
+				return Session.IsDirtyNoFlush();
 			}
 		}
 

--- a/QS.Project/DomainModel/UoW/UnitOfWorkWithoutRoot.cs
+++ b/QS.Project/DomainModel/UoW/UnitOfWorkWithoutRoot.cs
@@ -7,7 +7,7 @@ namespace QS.DomainModel.UoW
 	{
 		public object RootObject => null;
 
-		public bool HasChanges => Session.IsDirty();
+		public bool HasChanges => Session.IsDirtyNoFlush();
 
 		internal UnitOfWorkWithoutRoot(ISessionProvider sessionProvider, UnitOfWorkTitle title) : base(sessionProvider)
 		{

--- a/QS.Project/QS.Project.csproj
+++ b/QS.Project/QS.Project.csproj
@@ -342,6 +342,7 @@
     <Compile Include="ErrorReporting\ErrorReportingSettings.cs" />
     <Compile Include="ErrorReporting\IErrorReportingSettings.cs" />
     <Compile Include="Project.DB\NhDataBaseInfo.cs" />
+    <Compile Include="DomainModel\UoW\NhibernateExtend.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Project.Domain\" />


### PR DESCRIPTION
Есть давно известный баг https://github.com/nhibernate/nhibernate-core/issues/1413 в том что при вызове IsDirty хибернейт может сохранять изменения в базу. Частично это решается открытием транзакции. которая откатывается при отмене. Но если какие то из полей стоят not-null то проблема записи при проверке не исчезает. Поэтому реализована собственная проверка на изменения. Откуда взять код указано в начале класса.