### PR TITLE
Исправлен баг найденный тестом.

### DIFF
--- a/QS.LibsTest/Navigation/TdiNavigationManagerTest.cs
+++ b/QS.LibsTest/Navigation/TdiNavigationManagerTest.cs
@@ -259,7 +259,6 @@ namespace QS.Test.Navigation
 
 			var commonService = Substitute.For<ICommonServices>();
 			var interactiveMessage = Substitute.For<IInteractiveMessage>();
-			var interactiveService = Substitute.For<IInteractiveService>();
 			var uowFactory = Substitute.For<IUnitOfWorkFactory>();
 			var pageFactory = Substitute.For<IViewModelsPageFactory>();
 			var tabPageFactory = Substitute.For<ITdiPageFactory>();

--- a/QS.Project.Gtk/Navigation/TdiNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/TdiNavigationManager.cs
@@ -141,6 +141,9 @@ namespace QS.Navigation
 
 		private IPage FindOrCreateMasterPage(ITdiTab tab)
 		{
+			if (tab == null)
+				return null;
+
 			ITdiPage page = AllPages.OfType<ITdiPage>().FirstOrDefault(x => x.TdiTab == tab);
 			if(page == null) {
 				page = new TdiTabPage(tab, null);


### PR DESCRIPTION
Если мастер вкладка была null, то в списке страниц создавалась пустая страница, без вкладки.