### PR TITLE
Откат обновления пакета DiffPlex

### DIFF
--- a/QS.HistoryLog.Gtk/QS.HistoryLog.Gtk.csproj
+++ b/QS.HistoryLog.Gtk/QS.HistoryLog.Gtk.csproj
@@ -104,7 +104,7 @@
       <HintPath>..\packages\FluentNHibernate.2.1.2\lib\net461\FluentNHibernate.dll</HintPath>
     </Reference>
     <Reference Include="DiffPlex">
-      <HintPath>..\packages\DiffPlex.1.6.1\lib\net40\DiffPlex.dll</HintPath>
+      <HintPath>..\packages\DiffPlex.1.5.0\lib\net40\DiffPlex.dll</HintPath>
     </Reference>
     <Reference Include="Remotion.Linq">
       <HintPath>..\packages\Remotion.Linq.2.2.0\lib\net45\Remotion.Linq.dll</HintPath>
@@ -189,6 +189,4 @@
     <Folder Include="Dialogs\" />
   </ItemGroup>
   <Import Project="..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" />
-  <Import Project="..\packages\jnm2.ReferenceAssemblies.net35.1.0.0\build\jnm2.ReferenceAssemblies.net35.targets" Condition="Exists('..\packages\jnm2.ReferenceAssemblies.net35.1.0.0\build\jnm2.ReferenceAssemblies.net35.targets')" />
-  <Import Project="..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets" Condition="Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets')" />
 </Project>

--- a/QS.HistoryLog.Gtk/packages.config
+++ b/QS.HistoryLog.Gtk/packages.config
@@ -1,13 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
-  <package id="DiffPlex" version="1.6.1" targetFramework="net461" />
+  <package id="DiffPlex" version="1.5.0" targetFramework="net461" />
   <package id="FluentNHibernate" version="2.1.2" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
-  <package id="jnm2.ReferenceAssemblies.net35" version="1.0.0" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.NETCore.Platforms" version="3.1.0" targetFramework="net461" />
-  <package id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.0" targetFramework="net461" developmentDependency="true" />
-  <package id="Microsoft.NETFramework.ReferenceAssemblies.net461" version="1.0.0" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net461" />
   <package id="NHibernate" version="5.2.7" targetFramework="net461" />


### PR DESCRIPTION
Из-за не совместимости с пакетом Microsoft.NETFramework.ReferenceAssemblies.net461.
Обновление DiffPlex в библиотеке требует обновления до той же версии и в проекте водовоза.
А при обновлении версии DiffPlex добавляет зависимый пакет Microsoft.NETFramework.ReferenceAssemblies.net461. Он в свою очередь ломает сборку водовоза. После его добавления ни в одном файле не получается найти классы или пространство имен в пространстве имен Vodovoz. Например не может найти Domain namespace в Vodovoz.
Причину пока не удалось выяснить. Предлагаю если это возможно, пока откатить обновление этого пакета.