### PR TITLE
Исправил вызов события изменения.

### DIFF
--- a/QS.Project/ViewModels/Control/EEVM/EntityEntryViewModel.cs
+++ b/QS.Project/ViewModels/Control/EEVM/EntityEntryViewModel.cs
@@ -63,7 +63,7 @@ namespace QS.ViewModels.Control.EEVM
 				OnPropertyChanged(nameof(EntityTitle));
 				OnPropertyChanged(nameof(SensitiveCleanButton));
 				OnPropertyChanged(nameof(SensitiveViewButton));
-				Changed?.Invoke(this, new EntitySelectedEventArgs(value));
+				Changed?.Invoke(this, EventArgs.Empty);
 			}
 		}
 


### PR DESCRIPTION
Само событие сделано так что, оно не требует аргументов.
При этом EntitySelectedEventArgs не позволяет получать null в качестве entity. Поэтому мы падаем при попытке очистить поле.