### PR TITLE
Исправление бага с закрытием журналов.

### DIFF
--- a/QS.Project.Gtk/Project.Search.GtkUI/OneEntrySearchView.cs
+++ b/QS.Project.Gtk/Project.Search.GtkUI/OneEntrySearchView.cs
@@ -28,6 +28,14 @@ namespace QS.Project.Search.GtkUI
 			entrySearch.Changed += EntSearchText_Changed;
 		}
 
+		public OneEntrySearchView() : base()
+		{
+		}
+
+		public OneEntrySearchView(IntPtr raw) : base(raw)
+		{
+		}
+
 		void EntSearchText_Changed(object sender, EventArgs e)
 		{
 			if(QueryDelay != 0) {


### PR DESCRIPTION
Очень странный баг при закрытии журнала на винде вызывалось исключение  GLib.MissingIntPtrCtorException: GLib.Object subclass при в момент перебора всех дочерних виджетов. На линуксе такого не происходило. Пробовал разные варианты обойти проблему. Похоже добавление постых конструкторов самый адекватный вариант.