### PR TITLE
Не падаем при удалении обектов в базе, в которых есть поломанные ссылки

### DIFF
--- a/QS.Project/Deletion/Configuration/DeleteConfiguration.cs
+++ b/QS.Project/Deletion/Configuration/DeleteConfiguration.cs
@@ -22,7 +22,7 @@ namespace QS.Deletion.Configuration
 			ClassInfos.Add (info);
 		}
 
-		public DeleteInfoHibernate<TEntity> ExistingDeleteRule<TEntity> () where TEntity : IDomainObject
+		public DeleteInfoHibernate<TEntity> ExistingDeleteRule<TEntity> () where TEntity : class, IDomainObject
 		{
 			return ClassInfos.OfType<DeleteInfoHibernate<TEntity>>().First();
 		}
@@ -96,7 +96,7 @@ namespace QS.Deletion.Configuration
 		#region FluentConfig
 
 		public DeleteInfoHibernate<TEntity> AddHibernateDeleteInfo<TEntity> ()
-			where TEntity : IDomainObject
+			where TEntity : class, IDomainObject
 		{
 			var info = (DeleteInfoHibernate<TEntity>) ClassInfos.Find (i => i.ObjectClass == typeof(TEntity));
 			if (info != null)

--- a/QS.Project/Deletion/DeleteConfig.cs
+++ b/QS.Project/Deletion/DeleteConfig.cs
@@ -16,7 +16,7 @@ namespace QS.Deletion
 			Main.AddDeleteInfo(info);
 		}
 
-		public static DeleteInfoHibernate<TEntity> ExistingDeleteRule<TEntity> () where TEntity : IDomainObject
+		public static DeleteInfoHibernate<TEntity> ExistingDeleteRule<TEntity> () where TEntity : class, IDomainObject
 		{
 			return Main.ExistingDeleteRule<TEntity>();
 		}
@@ -39,7 +39,7 @@ namespace QS.Deletion
 		#region FluentConfig
 
 		public static DeleteInfoHibernate<TEntity> AddHibernateDeleteInfo<TEntity> ()
-			where TEntity : IDomainObject
+			where TEntity : class, IDomainObject
 		{
 			return Main.AddHibernateDeleteInfo<TEntity>();
 		}

--- a/QS.Project/DomainModel/UoW/IUnitOfWork.cs
+++ b/QS.Project/DomainModel/UoW/IUnitOfWork.cs
@@ -23,7 +23,7 @@ namespace QS.DomainModel.UoW
 
 		/// <param name="orUpdate">
 		/// По умолчанию установлен в true это значит то будет вызываться метод SaveOrUpdate вместо Save.
-		/// Этот параметр нуже тогда когда мы сохраняем много новых объектов, при использовании метода SaveOrUpdate Nhibernate перед INSERT 
+		/// Этот параметр нужен тогда когда мы сохраняем много новых объектов, при использовании метода SaveOrUpdate Nhibernate перед INSERT 
 		/// делает SELECT что бы проверить нет ли уже объекта для обновления. Что при большом количестве объектов приводит к задержкам сохранения.
 		/// </param>
 		void Save<TEntity>(TEntity entity, bool orUpdate = true) where TEntity : IDomainObject;

--- a/QSOrmProject/OrmReference.cs
+++ b/QSOrmProject/OrmReference.cs
@@ -216,6 +216,10 @@ namespace QSOrmProject
 			InitializePermissionValidator();
 			ConfigureDlg();
 		}
+		#region Конструкторы для обхода бага GLib.MissingIntPtrCtorException: GLib.Object 
+		public OrmReference(IntPtr raw) : base(raw){}
+		protected OrmReference(){}
+		#endregion
 
 		void ConfigureDlg()
 		{

--- a/QSOrmProject/ReferenceBase.cs
+++ b/QSOrmProject/ReferenceBase.cs
@@ -11,6 +11,14 @@ namespace QS
 {
 	public class ReferenceBase : Bin
 	{
+		#region Конструктор для обхода бага GLib.MissingIntPtrCtorException: GLib.Object 
+		public ReferenceBase(IntPtr raw) : base(raw){}
+		#endregion
+
+		protected ReferenceBase()
+		{
+		}
+
 		protected IPermissionResult permissionResult { get; set; }
 		protected virtual System.Type objectType { get; set; }
 		public virtual bool FailInitialize { get; private set; }


### PR DESCRIPTION
Иногда происходит нарушение ключенй например всем ссылкам в объекте проставился id=0 или что-то другое. Такие объекты до этого нельзя было удалить, так как механизм падал при попытке проверить ссылку на объект с id=0 которого нет в базе. В данном случае мы перехватываем экспешен что объекта нет. И просто не пытаемся его дальше проверять эту ветку, это просто неверная зависимость.