### PR TITLE
Не падаем если уведомление вызывается для свойства которое отсутствует у класса.

### DIFF
--- a/QS.Project/DomainModel/Entity/PropertyChangedBase.cs
+++ b/QS.Project/DomainModel/Entity/PropertyChangedBase.cs
@@ -19,8 +19,9 @@ namespace QS.DomainModel.Entity
 		{
 			if (PropertyChanged != null) {
 				PropertyChanged(this, new PropertyChangedEventArgs (propertyName));
-				if(!String.IsNullOrWhiteSpace(propertyName)) {
-					var attributes = this.GetType().GetProperty(propertyName).GetCustomAttributes(typeof(PropertyChangedAlsoAttribute), true);
+				var propertyInfo = this.GetType().GetProperty(propertyName);
+				if(propertyInfo != null) {
+					var attributes = propertyInfo.GetCustomAttributes(typeof(PropertyChangedAlsoAttribute), true);
 					foreach(PropertyChangedAlsoAttribute attribute in attributes)
 						foreach(string propName in attribute.PropertiesNames)
 							PropertyChanged(this, new PropertyChangedEventArgs(propName));


### PR DESCRIPTION
Понимаю что это не совсем здоровая ситуация. И по идеи обновление должно вызываться именно для реального свойства. Но в некоторых ситуациях хочеться сделать аля виртуальное свойство именно для уведомления. Например сослаться на какое то поле второго уровня в нутри класса. И так как имея передается в виде строки, то это работает. И для получения таких уведомлений реального свойства не требуется.