### PR TITLE
Не стирать имя целиком

### DIFF
--- a/QS.Project.Gtk/Widgets.GtkUI/EntityViewModelEntry.cs
+++ b/QS.Project.Gtk/Widgets.GtkUI/EntityViewModelEntry.cs
@@ -199,14 +199,6 @@ namespace QS.Widgets.GtkUI
 			ClearSubject();
 		}
 
-		[GLib.ConnectBefore]
-		protected void OnEntryObjectKeyPressEvent(object o, KeyPressEventArgs args)
-		{
-			if(args.Event.Key == Gdk.Key.Delete || args.Event.Key == Gdk.Key.BackSpace) {
-				ClearSubject();
-			}
-		}
-
 		private void ClearSubject()
 		{
 			Subject = null;

--- a/QS.Project.Gtk/gtk-gui/QS.Widgets.GtkUI.EntityViewModelEntry.cs
+++ b/QS.Project.Gtk/gtk-gui/QS.Widgets.GtkUI.EntityViewModelEntry.cs
@@ -81,7 +81,6 @@ namespace QS.Widgets.GtkUI
 				this.Child.ShowAll();
 			}
 			this.Hide();
-			this.entryObject.KeyPressEvent += new global::Gtk.KeyPressEventHandler(this.OnEntryObjectKeyPressEvent);
 			this.entryObject.Changed += new global::System.EventHandler(this.OnEntryObjectChanged);
 			this.entryObject.FocusOutEvent += new global::Gtk.FocusOutEventHandler(this.OnEntryObjectFocusOutEvent);
 			this.buttonClear.Clicked += new global::System.EventHandler(this.OnButtonClearClicked);

--- a/QS.Project.Gtk/gtk-gui/gui.stetic
+++ b/QS.Project.Gtk/gtk-gui/gui.stetic
@@ -2020,7 +2020,6 @@
             <property name="CanFocus">True</property>
             <property name="IsEditable">False</property>
             <property name="InvisibleChar">●</property>
-            <signal name="KeyPressEvent" handler="OnEntryObjectKeyPressEvent" />
             <signal name="Changed" handler="OnEntryObjectChanged" />
             <signal name="FocusOutEvent" handler="OnEntryObjectFocusOutEvent" />
           </widget>


### PR DESCRIPTION
Сейчас одно нажатие backspase в EntityViewModelEntry стирает имя целиком, что неудобно.