### PR TITLE
Закрываем вкладку если при проверку закрытия возникла ошибка

### DIFF
--- a/QS.Project.Gtk/Tdi/TdiNotebook.cs
+++ b/QS.Project.Gtk/Tdi/TdiNotebook.cs
@@ -255,7 +255,16 @@ namespace QS.Tdi.Gtk
 				return false;
 			}
 
-			if(SaveIfNeed(tab)) {
+			bool canClose = true;
+			try
+			{
+				canClose = SaveIfNeed(tab);
+			}
+			catch (Exception e)
+			{
+				logger.Error(e, "Возникла ошибка при проверке закрытия вкладки");
+			}
+			if(canClose) {
 				ForceCloseTab(tab, source);
 				return true;
 			}


### PR DESCRIPTION
Чтобы не возникало ситуации когда пользователь не может закрыть вкладку, потому что при вопросе о необходимости закрытия или при проверках внутри диалога могли возникнуть ошибки.