### PR TITLE
Добавлен проект библиотеки под dotnet

### DIFF
--- a/QS.Utilities/Properties/AssemblyInfo.cs
+++ b/QS.Utilities/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/QS.Utilities/QS.Utilities.dotnet.csproj
+++ b/QS.Utilities/QS.Utilities.dotnet.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
Потихоньку начинаем переводить библиотеки на работу под dot net Core. Пока опыт проекта манго для Водовоза показывает что проще всего создавать отдельный Солющен и проджек файл. потому что окружение как правило разно, и используются разные версии библиотек, при этом сам код обычно такой же. Если научимся нормально работать с мулти таргетом, можно начать делать по другому.