### PR TITLE
Исправляем баг со сворачиванием окна на виндовс

### DIFF
--- a/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
@@ -61,7 +61,9 @@ namespace QS.Navigation
 			gtkPage.GtkView = viewResolver.Resolve(page.ViewModel);
 			if(gtkPage.GtkView == null)
 				throw new InvalidOperationException($"View для {page.ViewModel.GetType()} не создано через {viewResolver.GetType()}.");
-			gtkPage.GtkDialog = new Gtk.Dialog(gtkPage.ViewModel.Title, gtkMasterPage?.GtkDialog, viewModel.IsModal ? DialogFlags.Modal : DialogFlags.DestroyWithParent);
+			gtkPage.GtkDialog = new Gtk.Dialog(gtkPage.ViewModel.Title, 
+				viewModel.IsModal ? gtkMasterPage?.GtkDialog : null, 
+				viewModel.IsModal ? DialogFlags.Modal : DialogFlags.DestroyWithParent);
 			var defaultsize = gtkPage.GtkView.GetType().GetAttribute<WindowSizeAttribute>(true);
 			gtkPage.GtkDialog.SetDefaultSize(defaultsize?.DefaultWidth ?? gtkPage.GtkView.WidthRequest, defaultsize?.DefaultHeight ?? gtkPage.GtkView.WidthRequest);
 			gtkPage.GtkDialog.VBox.Add(gtkPage.GtkView);

--- a/QS.Project.Gtk/Navigation/TdiNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/TdiNavigationManager.cs
@@ -293,7 +293,9 @@ namespace QS.Navigation
 			gtkPage.GtkView = viewResolver.Resolve(viewModel);
 			if(gtkPage.GtkView == null)
 				throw new InvalidOperationException($"View для {page.ViewModel.GetType()} не создано через {viewResolver.GetType()}.");
-			gtkPage.GtkDialog = new Gtk.Dialog(gtkPage.ViewModel.Title, tdiNotebook.Toplevel as Window, viewModel.IsModal ? DialogFlags.Modal : DialogFlags.DestroyWithParent);
+			gtkPage.GtkDialog = new Gtk.Dialog(gtkPage.ViewModel.Title, 
+				viewModel.IsModal ? tdiNotebook.Toplevel as Window : null, 
+				viewModel.IsModal ? DialogFlags.Modal : DialogFlags.DestroyWithParent);
 			var defaultsize = gtkPage.GtkView.GetType().GetAttribute<WindowSizeAttribute>(true);
 			gtkPage.GtkDialog.SetDefaultSize(defaultsize?.DefaultWidth ?? gtkPage.GtkView.WidthRequest, defaultsize?.DefaultHeight ?? gtkPage.GtkView.WidthRequest);
 			gtkPage.GtkDialog.VBox.Add(gtkPage.GtkView);


### PR DESCRIPTION
До этого при сворачивании дополнительного окна на винде так же сорачивалось и основное оно программы. что выглядит странно в тех случаях когда окно не модальное.