### PR TITLE
Откат Mysql.Data до версии 8.0.19 из-за ошибки в новой версии в работе с Nullable GUID полями.

### DIFF
--- a/Modules/CustomFields/QSCustomFields.csproj
+++ b/Modules/CustomFields/QSCustomFields.csproj
@@ -31,6 +31,10 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MySql.Data, Version=8.0.19.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\..\packages\MySql.Data.8.0.19\lib\net452\MySql.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
@@ -84,14 +88,9 @@
     <Reference Include="K4os.Compression.LZ4.Streams">
       <HintPath>..\..\packages\K4os.Compression.LZ4.Streams.1.2.6\lib\net45\K4os.Compression.LZ4.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="MySql.Data">
-      <HintPath>..\..\packages\MySql.Data.8.0.22\lib\net452\MySql.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Ubiety.Dns.Core">
-      <HintPath>..\..\packages\MySql.Data.8.0.22\lib\net452\Ubiety.Dns.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Zstandard.Net">
-      <HintPath>..\..\packages\MySql.Data.8.0.22\lib\net452\Zstandard.Net.dll</HintPath>
+    <Reference Include="Ubiety.Dns.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\..\packages\MySql.Data.8.0.19\lib\net452\Ubiety.Dns.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Modules/CustomFields/packages.config
+++ b/Modules/CustomFields/packages.config
@@ -5,7 +5,7 @@
   <package id="K4os.Compression.LZ4" version="1.2.6" targetFramework="net452" />
   <package id="K4os.Compression.LZ4.Streams" version="1.2.6" targetFramework="net452" />
   <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net452" />
-  <package id="MySql.Data" version="8.0.22" targetFramework="net452" />
+  <package id="MySql.Data" version="8.0.19" targetFramework="net452" />
   <package id="NLog" version="4.7.5" targetFramework="net452" />
   <package id="SSH.NET" version="2016.1.0" targetFramework="net452" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net452" />

--- a/Modules/QSAttachment/QSAttachment.csproj
+++ b/Modules/QSAttachment/QSAttachment.csproj
@@ -36,6 +36,10 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MySql.Data, Version=8.0.19.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\..\packages\MySql.Data.8.0.19\lib\net452\MySql.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
@@ -92,14 +96,9 @@
     <Reference Include="K4os.Compression.LZ4.Streams">
       <HintPath>..\..\packages\K4os.Compression.LZ4.Streams.1.2.6\lib\net45\K4os.Compression.LZ4.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="MySql.Data">
-      <HintPath>..\..\packages\MySql.Data.8.0.22\lib\net452\MySql.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Ubiety.Dns.Core">
-      <HintPath>..\..\packages\MySql.Data.8.0.22\lib\net452\Ubiety.Dns.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Zstandard.Net">
-      <HintPath>..\..\packages\MySql.Data.8.0.22\lib\net452\Zstandard.Net.dll</HintPath>
+    <Reference Include="Ubiety.Dns.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\..\packages\MySql.Data.8.0.19\lib\net452\Ubiety.Dns.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Modules/QSAttachment/packages.config
+++ b/Modules/QSAttachment/packages.config
@@ -6,7 +6,7 @@
   <package id="K4os.Compression.LZ4" version="1.2.6" targetFramework="net452" />
   <package id="K4os.Compression.LZ4.Streams" version="1.2.6" targetFramework="net452" />
   <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net452" />
-  <package id="MySql.Data" version="8.0.22" targetFramework="net452" />
+  <package id="MySql.Data" version="8.0.19" targetFramework="net452" />
   <package id="NLog" version="4.7.5" targetFramework="net452" />
   <package id="SSH.NET" version="2016.1.0" targetFramework="net452" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net452" />

--- a/QS.Project.Gtk/QS.Project.Gtk.csproj
+++ b/QS.Project.Gtk/QS.Project.Gtk.csproj
@@ -31,6 +31,10 @@
     <NoStdLib>false</NoStdLib>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MySql.Data, Version=8.0.19.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\MySql.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <Package>gtk-sharp-2.0</Package>
@@ -121,15 +125,6 @@
     <Reference Include="K4os.Compression.LZ4.Streams">
       <HintPath>..\packages\K4os.Compression.LZ4.Streams.1.2.6\lib\net46\K4os.Compression.LZ4.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="MySql.Data">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\MySql.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Ubiety.Dns.Core">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Ubiety.Dns.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Zstandard.Net">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Zstandard.Net.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.1\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
@@ -138,6 +133,10 @@
     </Reference>
     <Reference Include="Autofac">
       <HintPath>..\packages\Autofac.5.2.0\lib\net461\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="Ubiety.Dns.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\Ubiety.Dns.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/QS.Project.Gtk/packages.config
+++ b/QS.Project.Gtk/packages.config
@@ -9,7 +9,7 @@
   <package id="K4os.Compression.LZ4.Streams" version="1.2.6" targetFramework="net461" />
   <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net461" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" targetFramework="net461" />
-  <package id="MySql.Data" version="8.0.22" targetFramework="net461" />
+  <package id="MySql.Data" version="8.0.19" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="NHibernate" version="5.3.3" targetFramework="net461" />
   <package id="NLog" version="4.7.5" targetFramework="net461" />

--- a/QS.Project/QS.Project.csproj
+++ b/QS.Project/QS.Project.csproj
@@ -29,6 +29,10 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MySql.Data, Version=8.0.19.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\MySql.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="Antlr3.Runtime">
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
@@ -103,16 +107,6 @@
     <Reference Include="K4os.Compression.LZ4.Streams">
       <HintPath>..\packages\K4os.Compression.LZ4.Streams.1.2.6\lib\net46\K4os.Compression.LZ4.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="MySql.Data">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\MySql.Data.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Ubiety.Dns.Core">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Ubiety.Dns.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Zstandard.Net">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Zstandard.Net.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.1\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
@@ -121,6 +115,10 @@
     </Reference>
     <Reference Include="Autofac">
       <HintPath>..\packages\Autofac.5.2.0\lib\net461\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="Ubiety.Dns.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\Ubiety.Dns.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/QS.Project/packages.config
+++ b/QS.Project/packages.config
@@ -10,7 +10,7 @@
   <package id="K4os.Compression.LZ4.Streams" version="1.2.6" targetFramework="net461" />
   <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net461" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" targetFramework="net461" />
-  <package id="MySql.Data" version="8.0.22" targetFramework="net461" />
+  <package id="MySql.Data" version="8.0.19" targetFramework="net461" />
   <package id="NHibernate" version="5.3.3" targetFramework="net461" />
   <package id="NLog" version="4.7.5" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.2.0" targetFramework="net461" />

--- a/QS.Updater.Gtk/QS.Updater.Gtk.csproj
+++ b/QS.Updater.Gtk/QS.Updater.Gtk.csproj
@@ -49,6 +49,14 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
+    <Reference Include="MySql.Data, Version=8.0.19.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\MySql.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MySqlBackup, Version=2.3.1.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\MySqlBackup.NET.2.3.1\lib\net452\MySqlBackup.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="gdk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="Nini">
@@ -59,9 +67,6 @@
     <Reference Include="System.Data" />
     <Reference Include="Mono.Posix" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="MySqlBackup">
-      <HintPath>..\packages\MySqlBackup.NET.2.3.3.1\lib\net452\MySqlBackup.dll</HintPath>
-    </Reference>
     <Reference Include="System.ComponentModel" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
@@ -110,14 +115,9 @@
     <Reference Include="K4os.Compression.LZ4.Streams">
       <HintPath>..\packages\K4os.Compression.LZ4.Streams.1.2.6\lib\net46\K4os.Compression.LZ4.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="MySql.Data">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\MySql.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Ubiety.Dns.Core">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Ubiety.Dns.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Zstandard.Net">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Zstandard.Net.dll</HintPath>
+    <Reference Include="Ubiety.Dns.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\Ubiety.Dns.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/QS.Updater.Gtk/packages.config
+++ b/QS.Updater.Gtk/packages.config
@@ -5,8 +5,8 @@
   <package id="K4os.Compression.LZ4" version="1.2.6" targetFramework="net461" />
   <package id="K4os.Compression.LZ4.Streams" version="1.2.6" targetFramework="net461" />
   <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net461" />
-  <package id="MySql.Data" version="8.0.22" targetFramework="net461" />
-  <package id="MySqlBackup.NET" version="2.3.3.1" targetFramework="net461" />
+  <package id="MySql.Data" version="8.0.19" targetFramework="net461" />
+  <package id="MySqlBackup.NET" version="2.3.1" targetFramework="net461" />
   <package id="NLog" version="4.7.5" targetFramework="net461" />
   <package id="SSH.NET" version="2016.1.0" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />

--- a/QSOrmProject/QSOrmProject.csproj
+++ b/QSOrmProject/QSOrmProject.csproj
@@ -31,6 +31,10 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MySql.Data, Version=8.0.19.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\MySql.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <Package>gtk-sharp-2.0</Package>
@@ -121,20 +125,15 @@
     <Reference Include="K4os.Compression.LZ4.Streams">
       <HintPath>..\packages\K4os.Compression.LZ4.Streams.1.2.6\lib\net46\K4os.Compression.LZ4.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="MySql.Data">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\MySql.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Ubiety.Dns.Core">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Ubiety.Dns.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Zstandard.Net">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Zstandard.Net.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.1\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Autofac">
       <HintPath>..\packages\Autofac.5.2.0\lib\net461\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="Ubiety.Dns.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\Ubiety.Dns.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/QSOrmProject/packages.config
+++ b/QSOrmProject/packages.config
@@ -10,7 +10,7 @@
   <package id="K4os.Compression.LZ4.Streams" version="1.2.6" targetFramework="net461" />
   <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net461" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.1" targetFramework="net461" />
-  <package id="MySql.Data" version="8.0.22" targetFramework="net461" />
+  <package id="MySql.Data" version="8.0.19" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="NHibernate" version="5.3.3" targetFramework="net461" />
   <package id="NLog" version="4.7.5" targetFramework="net461" />

--- a/QSProjectsLib/QSProjectsLib.csproj
+++ b/QSProjectsLib/QSProjectsLib.csproj
@@ -32,6 +32,10 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MySql.Data, Version=8.0.19.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\MySql.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f">
       <Package>gtk-sharp-2.0</Package>
@@ -90,14 +94,9 @@
     <Reference Include="K4os.Compression.LZ4.Streams">
       <HintPath>..\packages\K4os.Compression.LZ4.Streams.1.2.6\lib\net45\K4os.Compression.LZ4.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="MySql.Data">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\MySql.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Ubiety.Dns.Core">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Ubiety.Dns.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Zstandard.Net">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Zstandard.Net.dll</HintPath>
+    <Reference Include="Ubiety.Dns.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\Ubiety.Dns.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/QSProjectsLib/packages.config
+++ b/QSProjectsLib/packages.config
@@ -5,7 +5,7 @@
   <package id="K4os.Compression.LZ4" version="1.2.6" targetFramework="net452" />
   <package id="K4os.Compression.LZ4.Streams" version="1.2.6" targetFramework="net452" />
   <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net452" />
-  <package id="MySql.Data" version="8.0.22" targetFramework="net452" />
+  <package id="MySql.Data" version="8.0.19" targetFramework="net452" />
   <package id="NLog" version="4.7.5" targetFramework="net452" />
   <package id="SSH.NET" version="2016.1.0" targetFramework="net452" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net452" />

--- a/QSSupportLib/QSSupportLib.csproj
+++ b/QSSupportLib/QSSupportLib.csproj
@@ -32,6 +32,10 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MySql.Data, Version=8.0.19.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\MySql.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
     <Reference Include="System.Data" />
@@ -89,14 +93,9 @@
     <Reference Include="K4os.Compression.LZ4.Streams">
       <HintPath>..\packages\K4os.Compression.LZ4.Streams.1.2.6\lib\net46\K4os.Compression.LZ4.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="MySql.Data">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\MySql.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Ubiety.Dns.Core">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Ubiety.Dns.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Zstandard.Net">
-      <HintPath>..\packages\MySql.Data.8.0.22\lib\net452\Zstandard.Net.dll</HintPath>
+    <Reference Include="Ubiety.Dns.Core, Version=2.2.1.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d">
+      <HintPath>..\packages\MySql.Data.8.0.19\lib\net452\Ubiety.Dns.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/QSSupportLib/packages.config
+++ b/QSSupportLib/packages.config
@@ -5,7 +5,7 @@
   <package id="K4os.Compression.LZ4" version="1.2.6" targetFramework="net461" />
   <package id="K4os.Compression.LZ4.Streams" version="1.2.6" targetFramework="net461" />
   <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net461" />
-  <package id="MySql.Data" version="8.0.22" targetFramework="net461" />
+  <package id="MySql.Data" version="8.0.19" targetFramework="net461" />
   <package id="NLog" version="4.7.5" targetFramework="net461" />
   <package id="SSH.NET" version="2016.1.0" targetFramework="net452" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />


### PR DESCRIPTION
При чтении таких полей внутри Mysql.Data не правильно проверяется длина и падает при невозможности использования значения длины -1.