### PR TITLE
Заполняем заголовки диалогов текстом по умолчанию.

### DIFF
--- a/QS.Project.Gtk/Dialog.GtkUI/GtkQuestionDialogsInteractive.cs
+++ b/QS.Project.Gtk/Dialog.GtkUI/GtkQuestionDialogsInteractive.cs
@@ -13,7 +13,7 @@ namespace QS.Dialog.GtkUI
 								   ButtonsType.YesNo,
 								   message);
 			md.SetPosition(WindowPosition.Center);
-			md.Title = title;
+			md.Title = title ?? "Вопрос";
 			md.ShowAll();
 			bool result = md.Run() == (int)ResponseType.Yes;
 			md.Destroy();

--- a/QS.Project.Gtk/Dialog.GtkUI/MessageDialogHelper.cs
+++ b/QS.Project.Gtk/Dialog.GtkUI/MessageDialogHelper.cs
@@ -47,7 +47,7 @@ namespace QS.Dialog.GtkUI
 				                   ButtonsType.Ok,
 				                   warning);
 			md.SetPosition (WindowPosition.Center);
-			md.Title = title;
+			md.Title = title ?? "Предупреждение";
 			md.ShowAll ();
 			md.Run ();
 			md.Destroy ();
@@ -86,7 +86,7 @@ namespace QS.Dialog.GtkUI
 			    useMarkup,
 				error);
 			md.SetPosition (WindowPosition.Center);
-			md.Title = title;
+			md.Title = title ?? "Ошибка";
 			md.ShowAll ();
 			md.Run ();
 			md.Destroy ();
@@ -120,7 +120,7 @@ namespace QS.Dialog.GtkUI
 				ButtonsType.Ok,
 				message);
 			md.SetPosition (WindowPosition.Center);
-			md.Title = title;
+			md.Title = title ?? "Информация";
 			md.ShowAll ();
 			md.Run ();
 			md.Destroy ();


### PR DESCRIPTION
Это лучше чем просто название экзешника, в случае если программист не позаботился об указании специфичного текста.