### PR TITLE
Adds GCCollect to clean memory after reports

### DIFF
--- a/QS.Project.Gtk/Tdi/TdiNotebook.cs
+++ b/QS.Project.Gtk/Tdi/TdiNotebook.cs
@@ -407,6 +407,7 @@ namespace QS.Tdi.Gtk
 				(tab as IDisposable).Dispose();
 				tab = null;
 			}
+			GC.Collect();
 		}
 
 		internal void OnTabClosed(ITdiTab tab, CloseSource source)


### PR DESCRIPTION
Очень грязный хак, который необходим для очистки памяти при закрытии вкладки. Однако без него не получится очистить память после отчётов как на приложенном графике.

![image](https://user-images.githubusercontent.com/1447790/101789514-71d27480-3b12-11eb-8465-5da5a02a4d77.png)
