### PR TITLE
Предложен первоначальный вариант нового интерфейса обращения к конфигурации в Ini файле

### DIFF
--- a/QS.MachineConfig/Configuration/IChangeableConfiguration.cs
+++ b/QS.MachineConfig/Configuration/IChangeableConfiguration.cs
@@ -1,0 +1,19 @@
+﻿using System;
+namespace QS.Configuration
+{
+	/// <summary>
+	/// Интерфейс который в плане чтения конфигурации должен быть похожим на IConfiguration от MS
+	/// Чтобы он был заменяем без переписывания кода и в последствии
+	/// И был бы как IConfiguration более универсальным. То есть не связанным с местом хранения данных.
+	/// </summary>
+	public interface IChangeableConfiguration
+	{
+		/// <summary>
+		/// Можно получать и устанавливать значение через Item[key]
+		/// </summary>
+		/// <param name="key">Key.</param>
+		string this[string key] { get; set; }
+
+		void Reload();
+	}
+}

--- a/QS.MachineConfig/Configuration/IniFileConfiguration.cs
+++ b/QS.MachineConfig/Configuration/IniFileConfiguration.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.IO;
+using Nini.Config;
+
+namespace QS.Configuration
+{
+	public class IniFileConfiguration : IChangeableConfiguration
+	{
+		private readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+		private IniConfigSource configSource;
+
+		public readonly string IniFile;
+
+		public IniFileConfiguration(string iniFile)
+		{
+			if(string.IsNullOrWhiteSpace(iniFile)) {
+				throw new ArgumentException("Имя ini файла должно быть указано.", nameof(iniFile));
+			}
+			this.IniFile = iniFile;
+
+			if(File.Exists(iniFile)) {
+				configSource = new IniConfigSource(iniFile);
+				configSource.Reload();
+			}
+			else {
+				logger.Warn("Конфигурационный фаил {0} не найден. Создан новый.", iniFile);
+				configSource = new IniConfigSource();
+				configSource.Save(iniFile);
+			}
+
+			configSource.AutoSave = true;
+		}
+
+		/// <summary>
+		/// Получаем или устанавливаем элемент. В ключе секцию указываем через ":"
+		/// Например "Секция:параметер"
+		/// </summary>
+		/// <value>The item.</value>
+		public string this[string key] {
+			get {
+				ParseKey(key, out string section, out string parameter);
+				return configSource.Configs[section]?.Get(parameter);
+			}
+			set {
+				ParseKey(key, out string section, out string parameter);
+				if(configSource.Configs[section] == null && value != null)
+					configSource.AddConfig(section);
+				if(value != null)
+					configSource.Configs[section].Set(parameter, value);
+				if(value == null && configSource.Configs[section]?.Contains(parameter) == true) {
+					configSource.Configs[section].Remove(parameter);
+					if(configSource.Configs[section].GetKeys().Length == 0) {
+						configSource.Configs.Remove((IConfig)configSource.Configs[section]);
+						configSource.Save();
+					}
+				}
+			}
+		}
+
+		public void Reload()
+		{
+			configSource.Reload();
+		}
+
+		#region private
+		private void ParseKey(string key, out string section, out string parameter)
+		{
+			section = null;
+			parameter = null;
+
+			var indexСolon = key.IndexOf(':');
+			if(indexСolon > 0) {
+				section = key.Substring(0, indexСolon);
+				parameter = key.Substring(indexСolon + 1);
+			}
+			else
+				parameter = key;
+		}
+		#endregion
+	}
+}

--- a/QS.MachineConfig/DefaultMachineConfig.cs
+++ b/QS.MachineConfig/DefaultMachineConfig.cs
@@ -4,6 +4,7 @@ using Nini.Config;
 
 namespace QSMachineConfig
 {
+    [Obsolete("Переходите на интерфейс IChangeableConfiguration который абстрагирует работу с конфигурацие от конкретной реализации и библиотеки Nini.")]
     public class DefaultMachineConfig : IMachineConfig
     {
         private readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();

--- a/QS.MachineConfig/IMachineConfig.cs
+++ b/QS.MachineConfig/IMachineConfig.cs
@@ -1,8 +1,10 @@
-﻿using Nini.Config;
+﻿using System;
+using Nini.Config;
 
 namespace QSMachineConfig
 {
-    public interface IMachineConfig
+	[Obsolete("Переходите на интерфейс IChangeableConfiguration который абстрагирует работу с конфигурацие от конкретной реализации и библиотеки Nini.")]
+	public interface IMachineConfig
     {
         IniConfigSource ConfigSource { get; set; }
         string ConfigFileName { get; set; }

--- a/QS.MachineConfig/MachineConfig.cs
+++ b/QS.MachineConfig/MachineConfig.cs
@@ -3,6 +3,7 @@ using Nini.Config;
 
 namespace QSMachineConfig
 {
+	[Obsolete("Переходите на интерфейс IChangeableConfiguration который абстрагирует работу с конфигурацие от конкретной реализации и библиотеки Nini.")]
 	public static class MachineConfig
 	{
 		private static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger ();

--- a/QS.MachineConfig/QS.MachineConfig.csproj
+++ b/QS.MachineConfig/QS.MachineConfig.csproj
@@ -5,7 +5,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{769710D2-BF98-4120-9E07-67BD740CFA1D}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>QSMachineConfig</RootNamespace>
+    <RootNamespace>QS</RootNamespace>
     <AssemblyName>QS.MachineConfig</AssemblyName>
     <ReleaseVersion>1.0</ReleaseVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
@@ -53,9 +53,14 @@
     <Compile Include="IMachineConfig.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MachineConfig.cs" />
+    <Compile Include="Configuration\IChangeableConfiguration.cs" />
+    <Compile Include="Configuration\IniFileConfiguration.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.7.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Configuration\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Пока интерфейс имеет только базовую, но рабочую реализацию.
У меня нет 100% уверенности в правильность этого решения. Вообще в идеале хотелось бы перейти на конфигурации от MS IConfiguration, которая во всю используется в net. Core и доступна из нугет пакетов во фреймворке. НО она работает только на чтение. То есть изменять значения там нельзя. А при нашем использовании это очень часто надо. Но при этом в новой конфигурации все таки хочется попробовать реализовать интерфейс асбтрагированный от конкретного места хранения (ini file) и отвязанный от nini. В текущем интерфейсе IMachineConfig работа происходит напрямую с Nini. Это возможно вызовет проблемы при переводе библиотек на Core, так как по-моему в Nini не развивается совсем. Есть какой то пакет Nini в названии для нет стандарта, но на него еще надо смотреть. В идеале уйти на более универсальную конфигурацию. А место хранения ее настраивать в проекте. С другой стороны Nini передоставляет расширеный функционал по доступу к данных. Хотя не помню чтобы мы его часто использовали. В общем хочется либо услышать аргументы что это не надо и в перспективе не унифицирует доступ к различным параметрам конфигурации для модулей. Либо предложения по доработке. Например, я изначально планировал делать клон IConfiguration, но потом увидел что доступ к параметрам там проиходит через свойство Item, мне не удалось добавить индексатор на свойство Item, а делать отдельный класс аля колеекция, для реализации доступа через индексатор, тоже показалось, странных. Но может быть вы проголосуете именно за более приближенный к IConfiguration вариант. Тогда по идеи если где то массово будет использоваться оригинальный IConfiguration классы реализующие наш интерфейс смогут реализовывать и его на чтение. Давайте подумаем, вместе.