### PR TITLE
Исправлена утечка виджетов.

### DIFF
--- a/QS.Project.Gtk/Tdi/TdiNotebook.cs
+++ b/QS.Project.Gtk/Tdi/TdiNotebook.cs
@@ -299,6 +299,8 @@ namespace QS.Tdi.Gtk
 			AskToCloseTab(tab.Tab, CloseSource.ClosePage);
 		}
 
+
+		/// <returns><c>true</c>, если можно закрывать вкладку, если закрытие вкладки отменено то <c>false</c></returns>
 		private bool SaveIfNeed(ITdiTab tab)
 		{
 			if(CheckClosingSlaveTabs(tab))
@@ -324,12 +326,13 @@ namespace QS.Tdi.Gtk
 				md.Destroy();
 				if(result == (int)ResponseType.Yes) {
 					if(!dlg.Save()) {
-						logger.Warn("Вкладка не сохранена. Отмена закрытия...");
+						logger.Info("Вкладка не сохранена. Отмена закрытия...");
 						return false;
 					}
+					else
+						return true;
 				}
 				if(result == (int)ResponseType.No) {
-					GetTabBoxForTab(tab)?.Destroy();
 					return true;
 				}
 				if(result == (int)ResponseType.DeleteEvent)


### PR DESCRIPTION
В этом методе при выборе пользователем нет, виджет вкладки разрушался сразу же. Хотя вызвавший метод, все равно бы закрыл вкладку при ответе true. А так как вкладка разрушалась раньше. Нормального закрытия не происходило. Так как не вызывались правильно дестрои для внутренних виджетов в этой строке https://github.com/QualitySolution/QSProjects/blob/master/QS.Project.Gtk/Tdi/TdiNotebook.cs#L430 Из-за за этого могла быть утечка памяти в виджетах и так как виджет продолжал висеть в памяти. И происходили ошибки в обработке глобальных событий. На уже закрытых вкладках.