### PR TITLE
Добавлена возможность модифицировать запрос при подсчете строк

### DIFF
--- a/QS.Project/Project.Journal/DataLoader/ThreadDataLoader.cs
+++ b/QS.Project/Project.Journal/DataLoader/ThreadDataLoader.cs
@@ -84,6 +84,21 @@ namespace QS.Project.Journal.DataLoader
 		public void AddQuery<TRoot>(Func<IUnitOfWork, IQueryOver<TRoot>> queryFunc)
 			where TRoot : class , IDomainObject
 		{
+			QueryLoaders.Add(new DynamicQueryLoader<TRoot, TNode>((uow, isCounting) => queryFunc(uow), unitOfWorkFactory));
+		}
+
+		/// <summary>
+		/// Добавляем функцию получения запроса для загрузчика.
+		/// Если функция возвращает null запрос не будет выполнятся. Это поведение используется в ситуации с несколькими запросами,
+		/// в определенных обстоятельствах, например из-за параметров фильтра, некоторые запросы не имеет смысл выполнять.
+		/// </summary>
+		/// <param name="queryFunc">Функция получения запроса, имеет параметры: 
+		/// uow - для которого создается запрос 
+		/// isCounting - указание является ли запрос подсчетом количества строк</param>
+		/// <typeparam name="TRoot">Тип корня запроса</typeparam>
+		public void AddQuery<TRoot>(Func<IUnitOfWork, bool, IQueryOver<TRoot>> queryFunc)
+			where TRoot : class, IDomainObject
+		{
 			QueryLoaders.Add(new DynamicQueryLoader<TRoot, TNode>(queryFunc, unitOfWorkFactory));
 		}
 


### PR DESCRIPTION
Иногда бывают ситуация при которых запрос подсчитывает неправильное количество сторок, так как группировка данных пропадает, в таких запросах. Поэтому добавлена возможность, добавлять при формировании запроса, учитывать место его использования, и модифицировать для подсчета строк. Детали описал в документации https://github.com/QualitySolution/QSProjects/wiki/%D0%94%D0%B8%D0%B0%D0%BB%D0%BE%D0%B3%D0%B8-%D0%B6%D1%83%D1%80%D0%BD%D0%B0%D0%BB%D0%BE%D0%B2#%D0%9F%D0%BE%D0%B4%D1%81%D1%87%D0%B5%D1%82-%D0%BE%D0%B1%D1%89%D0%B5%D0%B3%D0%BE-%D0%BA%D0%BE%D0%BB%D0%B8%D1%87%D0%B5%D1%81%D1%82%D0%B2%D0%B0-%D1%81%D1%82%D1%80%D0%BE%D0%BA