### PR TITLE
Валидатор теперь может проверять несколько объектов

### DIFF
--- a/QS.LibsTest/ViewModels/Dialog/EntityDialogViewModelBaseTest.cs
+++ b/QS.LibsTest/ViewModels/Dialog/EntityDialogViewModelBaseTest.cs
@@ -1,4 +1,6 @@
-﻿using NSubstitute;
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using NSubstitute;
 using NUnit.Framework;
 using QS.DomainModel.UoW;
 using QS.Navigation;
@@ -24,7 +26,8 @@ namespace QS.Test.ViewModels.Dialog
 			uowBuilder.CreateUoW<ValidatedEntity>(uowFactory).Returns(uow);
 			var navigation = Substitute.For<INavigationManager>();
 			var validation = Substitute.For<IValidator>();
-			validation.Validate(entity, null).Returns(true);
+			validation.Validate(entity, Arg.Any<ValidationContext>()).Returns(true);
+			validation.Validate(Arg.Any<IEnumerable<ValidationRequest>>()).Returns(true);
 
 			var viewModel = new EntityDialogViewModelBase<ValidatedEntity>(uowBuilder, uowFactory, navigation, validation);
 
@@ -32,7 +35,7 @@ namespace QS.Test.ViewModels.Dialog
 			uow.Received().Save();
 		}
 
-		[Test(Description = "Проверяем что ViewModel сохраняет entity если проверка прошла.")]
+		[Test(Description = "Проверяем что ViewModel НЕ сохраняем entity если проверка НЕ прошла.")]
 		public void Validate_DontSaveIfValidationFailTest()
 		{
 			var entity = Substitute.For<ValidatedEntity>();
@@ -44,7 +47,8 @@ namespace QS.Test.ViewModels.Dialog
 			uowBuilder.CreateUoW<ValidatedEntity>(uowFactory).Returns(uow);
 			var navigation = Substitute.For<INavigationManager>();
 			var validation = Substitute.For<IValidator>();
-			validation.Validate(entity, null).Returns(false);
+			validation.Validate(entity, Arg.Any<ValidationContext>()).Returns(false);
+			validation.Validate(Arg.Any<IEnumerable<ValidationRequest>>()).Returns(false);
 
 			var viewModel = new EntityDialogViewModelBase<ValidatedEntity>(uowBuilder, uowFactory, navigation, validation);
 

--- a/QS.LibsTest/ViewModels/Dialog/EntityDialogViewModelBaseTest.cs
+++ b/QS.LibsTest/ViewModels/Dialog/EntityDialogViewModelBaseTest.cs
@@ -19,14 +19,14 @@ namespace QS.Test.ViewModels.Dialog
 			var uow = Substitute.For<IUnitOfWorkGeneric<ValidatedEntity>>();
 			uow.Root.Returns(entity);
 			uow.RootObject.Returns(entity);
-			var uowFacrory = Substitute.For<IUnitOfWorkFactory>();
+			var uowFactory = Substitute.For<IUnitOfWorkFactory>();
 			var uowBuilder = Substitute.For<IEntityUoWBuilder>();
-			uowBuilder.CreateUoW<ValidatedEntity>(uowFacrory).Returns(uow);
+			uowBuilder.CreateUoW<ValidatedEntity>(uowFactory).Returns(uow);
 			var navigation = Substitute.For<INavigationManager>();
 			var validation = Substitute.For<IValidator>();
 			validation.Validate(entity, null).Returns(true);
 
-			var viewModel = new EntityDialogViewModelBase<ValidatedEntity>(uowBuilder, uowFacrory, navigation, validation);
+			var viewModel = new EntityDialogViewModelBase<ValidatedEntity>(uowBuilder, uowFactory, navigation, validation);
 
 			Assert.That(viewModel.Save(), Is.True);
 			uow.Received().Save();
@@ -39,14 +39,14 @@ namespace QS.Test.ViewModels.Dialog
 			var uow = Substitute.For<IUnitOfWorkGeneric<ValidatedEntity>>();
 			uow.Root.Returns(entity);
 			uow.RootObject.Returns(entity);
-			var uowFacrory = Substitute.For<IUnitOfWorkFactory>();
+			var uowFactory = Substitute.For<IUnitOfWorkFactory>();
 			var uowBuilder = Substitute.For<IEntityUoWBuilder>();
-			uowBuilder.CreateUoW<ValidatedEntity>(uowFacrory).Returns(uow);
+			uowBuilder.CreateUoW<ValidatedEntity>(uowFactory).Returns(uow);
 			var navigation = Substitute.For<INavigationManager>();
 			var validation = Substitute.For<IValidator>();
 			validation.Validate(entity, null).Returns(false);
 
-			var viewModel = new EntityDialogViewModelBase<ValidatedEntity>(uowBuilder, uowFacrory, navigation, validation);
+			var viewModel = new EntityDialogViewModelBase<ValidatedEntity>(uowBuilder, uowFactory, navigation, validation);
 
 			Assert.That(viewModel.Save(), Is.False);
 			uow.DidNotReceive().Save();
@@ -59,12 +59,12 @@ namespace QS.Test.ViewModels.Dialog
 			var uow = Substitute.For<IUnitOfWorkGeneric<ValidatedEntity>>();
 			uow.Root.Returns(entity);
 			uow.RootObject.Returns(entity);
-			var uowFacrory = Substitute.For<IUnitOfWorkFactory>();
+			var uowFactory = Substitute.For<IUnitOfWorkFactory>();
 			var uowBuilder = Substitute.For<IEntityUoWBuilder>();
-			uowBuilder.CreateUoW<ValidatedEntity>(uowFacrory).Returns(uow);
+			uowBuilder.CreateUoW<ValidatedEntity>(uowFactory).Returns(uow);
 			var navigation = Substitute.For<INavigationManager>();
 
-			var viewModel = new EntityDialogViewModelBase<ValidatedEntity>(uowBuilder, uowFacrory, navigation);
+			var viewModel = new EntityDialogViewModelBase<ValidatedEntity>(uowBuilder, uowFactory, navigation);
 
 			Assert.That(viewModel.Save(), Is.True);
 			uow.Received().Save();

--- a/QS.Project/QS.Project.csproj
+++ b/QS.Project/QS.Project.csproj
@@ -328,6 +328,7 @@
     <Compile Include="Project.Versioning\Product\ProductEdition.cs" />
     <Compile Include="Project.DB\IConnectionFactory.cs" />
     <Compile Include="Project.DB\MySqlConnectionFactory.cs" />
+    <Compile Include="Validation\ValidationRequest.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Project.Domain\" />

--- a/QS.Project/Validation/IValidator.cs
+++ b/QS.Project/Validation/IValidator.cs
@@ -8,6 +8,10 @@ namespace QS.Validation
 	{
 		/// <returns>Возвращает <see langword="true"/> если объект корректен.</returns>
 		bool Validate(object validatableObject, ValidationContext validationContext = null);
+
+		/// <returns>Возвращает <see langword="true"/> если объекты корректены.</returns>
+		bool Validate(IEnumerable<ValidationRequest> requests);
+
 		/// <summary>
 		/// Детальные результаты последней проверки.
 		/// </summary>

--- a/QS.Project/Validation/ObjectValidator.cs
+++ b/QS.Project/Validation/ObjectValidator.cs
@@ -29,13 +29,21 @@ namespace QS.Validation
 		/// <returns>Возвращает <see langword="true"/> если объект корректен.</returns>
 		public bool Validate(object validatableObject, ValidationContext validationContext = null)
 		{
+			return Validate(new[] { new ValidationRequest(validatableObject, validationContext)});
+		}
+
+		/// <returns>Возвращает <see langword="true"/> если объекты корректны.</returns>
+		public bool Validate(IEnumerable<ValidationRequest> requests)
+		{
 			results.Clear();
 
-			if(validationContext == null) {
-				validationContext = new ValidationContext(validatableObject, null, null);
+			var isValid = true;
+
+			foreach(var request in requests) {
+				var isItemValid = Validator.TryValidateObject(request.ValidateObject, request.ValidationContext, results, true);
+				isValid &= isItemValid;
 			}
 
-			var isValid = Validator.TryValidateObject(validatableObject, validationContext, results, true);
 			if(!isValid && validationViewFactory != null) {
 				IValidationView view = validationViewFactory.CreateValidationView(results);
 				if(view == null) {

--- a/QS.Project/Validation/ValidationRequest.cs
+++ b/QS.Project/Validation/ValidationRequest.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace QS.Validation
+{
+	public class ValidationRequest
+	{
+		public ValidationRequest(object validateObject, ValidationContext context = null)
+		{
+			ValidateObject = validateObject;
+
+			if(context == null) 
+				ValidationContext = new ValidationContext(validateObject, null, null);
+			else 
+				ValidationContext = context;
+		}
+
+		public object ValidateObject { get; }
+		public ValidationContext ValidationContext { get; set; }
+	}
+}

--- a/QS.Project/ViewModels/Dialog/EntityDialogViewModelBase.cs
+++ b/QS.Project/ViewModels/Dialog/EntityDialogViewModelBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using QS.DomainModel.Entity;
 using QS.DomainModel.UoW;
 using QS.Navigation;
@@ -19,7 +18,7 @@ namespace QS.ViewModels.Dialog
 
 		public TEntity Entity => UoWGeneric.Root;
 
-		public EntityDialogViewModelBase(IEntityUoWBuilder uowBuilder, IUnitOfWorkFactory unitOfWorkFactory, INavigationManager navigation, IValidator validator = null) : base(unitOfWorkFactory, navigation)
+		public EntityDialogViewModelBase(IEntityUoWBuilder uowBuilder, IUnitOfWorkFactory unitOfWorkFactory, INavigationManager navigation, IValidator validator = null) : base(unitOfWorkFactory, navigation, validator)
 		{
 			if(uowBuilder == null) {
 				throw new ArgumentNullException(nameof(uowBuilder));
@@ -29,7 +28,7 @@ namespace QS.ViewModels.Dialog
 			if(Entity is INotifyPropertyChanged propertyChanged)
 				propertyChanged.PropertyChanged += Entity_PropertyChanged;
 
-			this.validator = validator;
+			Validations.Add(new ValidationRequest(Entity));
 		}
 
 		#region Создание имени диалога
@@ -77,26 +76,6 @@ namespace QS.ViewModels.Dialog
 				return title;
 			}
 			return Entity.ToString();
-		}
-
-		#endregion
-
-		#region Валидация сущности
-
-		protected ValidationContext ValidationContext { get; set; }
-
-		private readonly IValidator validator;
-
-		protected virtual bool Validate()
-		{
-			return validator?.Validate(Entity, ValidationContext) ?? true;
-		}
-
-		public override bool Save()
-		{
-			if (!Validate())
-				return false;
-			return base.Save();
 		}
 
 		#endregion

--- a/QS.Project/ViewModels/Dialog/UowDialogViewModelBase.cs
+++ b/QS.Project/ViewModels/Dialog/UowDialogViewModelBase.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using QS.DomainModel.UoW;
 using QS.Navigation;
+using QS.Validation;
 
 namespace QS.ViewModels.Dialog
 {
@@ -8,9 +11,10 @@ namespace QS.ViewModels.Dialog
 	{
 		protected readonly IUnitOfWorkFactory UnitOfWorkFactory;
 
-		protected UowDialogViewModelBase(IUnitOfWorkFactory unitOfWorkFactory, INavigationManager navigation) : base(navigation)
+		protected UowDialogViewModelBase(IUnitOfWorkFactory unitOfWorkFactory, INavigationManager navigation, IValidator validator = null) : base(navigation)
 		{
 			this.UnitOfWorkFactory = unitOfWorkFactory;
+			this.validator = validator;
 		}
 
 		private IUnitOfWork unitOfWork;
@@ -34,6 +38,9 @@ namespace QS.ViewModels.Dialog
 
 		public virtual bool Save()
 		{
+			if(!Validate())
+				return false;
+
 			if(UoW.RootObject != null)
 				UoW.Save();
 			else
@@ -51,5 +58,20 @@ namespace QS.ViewModels.Dialog
 		{
 			UoW?.Dispose();
 		}
+
+		#region Валидация
+
+		private readonly IValidator validator;
+		public readonly List<ValidationRequest> Validations = new List<ValidationRequest>();
+
+		protected virtual bool Validate()
+		{
+			if(validator == null || !Validations.Any())
+				return true;
+
+			return validator.Validate(Validations);
+		}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
Во ViewModel теперь можно добавить проверку не только основного объекта диалога, но и другие объекты, в том числе и саму ViewModel для проверки свойств напрямую не сохраняемых в БД.