### PR TITLE
Переделал GtkWindowsNavigationManager для того чтобы работали обычный view модели.

### DIFF
--- a/QS.Project.Gtk/Journal.GtkUI/JournalView.cs
+++ b/QS.Project.Gtk/Journal.GtkUI/JournalView.cs
@@ -14,12 +14,14 @@ using QS.Project.Search.GtkUI;
 using QS.Utilities;
 using QS.Utilities.Text;
 using QS.ViewModels;
+using QS.Views.Dialog;
 using QS.Views.GtkUI;
 using QS.Views.Resolve;
 using QSWidgetLib;
 
 namespace QS.Journal.GtkUI
 {
+	[WindowSize(900, 600)]
 	public partial class JournalView : TabViewBase<JournalViewModelBase>
 	{
 		private static Logger logger = LogManager.GetCurrentClassLogger();

--- a/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
@@ -56,18 +56,19 @@ namespace QS.Navigation
 			page.ViewModel.NavigationManager = this;
 			pages.Add(page);
 			var gtkPage = (IGtkWindowPage)page;
-			WindowDialogViewModelBase viewModel = (WindowDialogViewModelBase)page.ViewModel;
+			WindowDialogViewModelBase windowDialog = page.ViewModel as WindowDialogViewModelBase;
 			var gtkMasterPage = (IGtkWindowPage)masterPage;
 			gtkPage.GtkView = viewResolver.Resolve(page.ViewModel);
 			if(gtkPage.GtkView == null)
 				throw new InvalidOperationException($"View для {page.ViewModel.GetType()} не создано через {viewResolver.GetType()}.");
-			gtkPage.GtkDialog = new Gtk.Dialog(gtkPage.ViewModel.Title, 
-				viewModel.IsModal ? gtkMasterPage?.GtkDialog : null, 
-				viewModel.IsModal ? DialogFlags.Modal : DialogFlags.DestroyWithParent);
+			var isModal = windowDialog?.IsModal ?? false;
+			gtkPage.GtkDialog = new Gtk.Dialog(gtkPage.ViewModel.Title,
+				isModal ? gtkMasterPage?.GtkDialog : null,
+				isModal ? DialogFlags.Modal : DialogFlags.DestroyWithParent);
 			var defaultsize = gtkPage.GtkView.GetType().GetAttribute<WindowSizeAttribute>(true);
 			gtkPage.GtkDialog.SetDefaultSize(defaultsize?.DefaultWidth ?? gtkPage.GtkView.WidthRequest, defaultsize?.DefaultHeight ?? gtkPage.GtkView.WidthRequest);
 			gtkPage.GtkDialog.VBox.Add(gtkPage.GtkView);
-			if(viewModel.EnableMinimizeMaximize)
+			if(windowDialog?.EnableMinimizeMaximize ?? true)
 				gtkPage.GtkDialog.TypeHint = Gdk.WindowTypeHint.Normal;
 			gtkPage.GtkView.Show();
 			gtkPage.GtkDialog.Show();

--- a/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/GtkWindowsNavigationManager.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using Gamma.Utilities;
 using Gtk;
 using QS.Dialog;
-using QS.ViewModels.Dialog;
+using QS.ViewModels.Extension;
 using QS.Views.Dialog;
 using QS.Views.Resolve;
 
@@ -56,19 +56,19 @@ namespace QS.Navigation
 			page.ViewModel.NavigationManager = this;
 			pages.Add(page);
 			var gtkPage = (IGtkWindowPage)page;
-			WindowDialogViewModelBase windowDialog = page.ViewModel as WindowDialogViewModelBase;
+			IWindowDialogSettings windowSettings = page.ViewModel as IWindowDialogSettings;
 			var gtkMasterPage = (IGtkWindowPage)masterPage;
 			gtkPage.GtkView = viewResolver.Resolve(page.ViewModel);
 			if(gtkPage.GtkView == null)
 				throw new InvalidOperationException($"View для {page.ViewModel.GetType()} не создано через {viewResolver.GetType()}.");
-			var isModal = windowDialog?.IsModal ?? false;
+			var isModal = windowSettings?.IsModal ?? false;
 			gtkPage.GtkDialog = new Gtk.Dialog(gtkPage.ViewModel.Title,
 				isModal ? gtkMasterPage?.GtkDialog : null,
 				isModal ? DialogFlags.Modal : DialogFlags.DestroyWithParent);
 			var defaultsize = gtkPage.GtkView.GetType().GetAttribute<WindowSizeAttribute>(true);
 			gtkPage.GtkDialog.SetDefaultSize(defaultsize?.DefaultWidth ?? gtkPage.GtkView.WidthRequest, defaultsize?.DefaultHeight ?? gtkPage.GtkView.WidthRequest);
 			gtkPage.GtkDialog.VBox.Add(gtkPage.GtkView);
-			if(windowDialog?.EnableMinimizeMaximize ?? true)
+			if(windowSettings?.EnableMinimizeMaximize ?? true)
 				gtkPage.GtkDialog.TypeHint = Gdk.WindowTypeHint.Normal;
 			gtkPage.GtkView.Show();
 			gtkPage.GtkDialog.Show();

--- a/QS.Project/QS.Project.csproj
+++ b/QS.Project/QS.Project.csproj
@@ -329,6 +329,7 @@
     <Compile Include="Project.DB\IConnectionFactory.cs" />
     <Compile Include="Project.DB\MySqlConnectionFactory.cs" />
     <Compile Include="Validation\ValidationRequest.cs" />
+    <Compile Include="ViewModels\Extension\IWindowDialogSettings.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Project.Domain\" />

--- a/QS.Project/ViewModels/Dialog/WindowDialogViewModelBase.cs
+++ b/QS.Project/ViewModels/Dialog/WindowDialogViewModelBase.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using QS.Dialog;
 using QS.Navigation;
+using QS.ViewModels.Extension;
 
 namespace QS.ViewModels.Dialog
 {
-	public abstract class WindowDialogViewModelBase : DialogViewModelBase
+	public abstract class WindowDialogViewModelBase : DialogViewModelBase, IWindowDialogSettings
 	{
 		public bool IsModal { get; protected set; } = true;
-		public bool EnableMinimizeMaximize { get; protected set; }
+		public bool EnableMinimizeMaximize { get; protected set; } = false;
 		public WindowGravity WindowPosition { get; protected set; }
 
 		protected WindowDialogViewModelBase(INavigationManager navigation) : base(navigation)

--- a/QS.Project/ViewModels/Extension/IWindowDialogSettings.cs
+++ b/QS.Project/ViewModels/Extension/IWindowDialogSettings.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using QS.Dialog;
+
+namespace QS.ViewModels.Extension
+{
+	/// <summary>
+	/// При добавлении этого интерфейса на ViewModel, Мендеджеры навигации умеющие работать с отдельными окнами
+	/// должны открывать диалог в отдельном окне. Так же интерфейс позволяет указать некоторые параметры открытия
+	/// окна.
+	/// </summary>
+	public interface IWindowDialogSettings
+	{
+		/// <summary>
+		/// Окно должно быть модальным.
+		/// </summary>
+		bool IsModal { get; }
+		/// <summary>
+		/// Включает кнопки свернуть\развернуть у окна.
+		/// </summary>
+		bool EnableMinimizeMaximize { get; }
+		/// <summary>
+		/// Положение окна при открытии.
+		/// </summary>
+		WindowGravity WindowPosition { get; }
+	}
+}


### PR DESCRIPTION
Предыдущая реализация не открывала обычные viewModel например журналы. Не знаю как получилось, что завязались на дочерний класс.