### PR TITLE
Включил покрытие кода тестами для библиотека на dotnet

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ node {
    }
    stage('Test dotnet')
    {
+   	  fileOperations([folderDeleteOperation('**/TestResults')])
    	  sh 'dotnet test --collect:"XPlat Code Coverage" QSProjects/QSProjects.dotnet.sln'
    	  cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '**/TestResults/**/coverage.cobertura.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', onlyStable: false, zoomCoverageChart: false
    }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,8 @@ node {
    }
    stage('Test dotnet')
    {
-   	sh 'dotnet test QSProjects/QSProjects.dotnet.sln'
+   	  sh 'dotnet test --collect:"XPlat Code Coverage" QSProjects/QSProjects.dotnet.sln'
+   	  cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '**/TestResults/**/coverage.cobertura.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', onlyStable: false, zoomCoverageChart: false
    }
    stage('Build Net4.x') {
         sh 'msbuild /p:Configuration=Debug /p:Platform=x86 QSProjects/QSProjectsLib.sln'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,9 +21,10 @@ node {
    }
    stage('Test dotnet')
    {
-   	  fileOperations([folderDeleteOperation('**/TestResults')])
-   	  sh 'dotnet test --collect:"XPlat Code Coverage" QSProjects/QSProjects.dotnet.sln'
+   	  sh 'rm -rf QSProjects/QS.LibsTest.Core/TestResults'
+   	  sh 'dotnet test --logger trx --collect:"XPlat Code Coverage" QSProjects/QSProjects.dotnet.sln'
    	  cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '**/TestResults/**/coverage.cobertura.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', onlyStable: false, zoomCoverageChart: false
+   	  [$class: 'MSTestPublisher', testResultsFile:"**/*.trx", failOnError: true, keepLongStdio: true]
    }
    stage('Build Net4.x') {
         sh 'msbuild /p:Configuration=Debug /p:Platform=x86 QSProjects/QSProjectsLib.sln'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ node {
    	  sh 'rm -rf QSProjects/QS.LibsTest.Core/TestResults'
    	  sh 'dotnet test --logger trx --collect:"XPlat Code Coverage" QSProjects/QSProjects.dotnet.sln'
    	  cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '**/TestResults/**/coverage.cobertura.xml', conditionalCoverageTargets: '70, 0, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', onlyStable: false, zoomCoverageChart: false
-   	  [$class: 'MSTestPublisher', testResultsFile:"**/*.trx", failOnError: true, keepLongStdio: true]
+   	  mstest testResultsFile:"**/*.trx", keepLongStdio: true
    }
    stage('Build Net4.x') {
         sh 'msbuild /p:Configuration=Debug /p:Platform=x86 QSProjects/QSProjectsLib.sln'


### PR DESCRIPTION
Дополнительно разобрался как сделать, чтобы тесты библиотек dotnet и net framework объединялись и показывались на дженкинсе вместе.