### PR TITLE
Ускорение прогресса.

### DIFF
--- a/QS.Project.Gtk/Widgets/ProgressWidget.cs
+++ b/QS.Project.Gtk/Widgets/ProgressWidget.cs
@@ -27,7 +27,6 @@ namespace QS.Widgets
 							Adjustment.Upper
 						   );
 			GtkHelper.WaitRedraw();
-			System.Threading.Thread.Sleep(1000);
 		}
 
 		public void Close()

--- a/QS.Project.Gtk/Widgets/ProgressWidget.cs
+++ b/QS.Project.Gtk/Widgets/ProgressWidget.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using Gtk;
 using QS.Dialog;
@@ -22,7 +22,7 @@ namespace QS.Widgets
 
 			Adjustment.Value += addValue;
 			if(Adjustment.Value > Adjustment.Upper)
-				logger.Warn("Значение ({0}) прогресс бара в статусной строке больше максимального ({1})",
+				logger.Warn("Значение ({0}) прогресс больше максимального ({1})",
 							Adjustment.Value,
 							Adjustment.Upper
 						   );


### PR DESCRIPTION
Из-за этого косяка прогресс на каждом шаге ждал 1 секунду. Поэтому все операции использующие это прогресс шли долго.