### PR TITLE
Добавлена поддержка View со вторым аргументом в конструкторе

### DIFF
--- a/QS.Project.Gtk/Views/Resolve/ClassNamesBaseGtkViewResolver.cs
+++ b/QS.Project.Gtk/Views/Resolve/ClassNamesBaseGtkViewResolver.cs
@@ -41,6 +41,10 @@ namespace QS.Views.Resolve
 			foreach(var assambly in lookupAssemblies) {
 				Type viewClass = assambly.GetType(expectedViewName);
 				if(viewClass != null) {
+					var construstorWithResolver = viewClass.GetConstructor(new[] { viewModel.GetType(), typeof(IGtkViewResolver) });
+					if(construstorWithResolver != null) {
+						return (Widget)construstorWithResolver.Invoke(new object[] { viewModel, this });
+					}
 					return (Widget)Activator.CreateInstance(viewClass, viewModel);
 				}
 			}


### PR DESCRIPTION
Очень часто возникает ситуации когда мы во view имеем несколько вложенных view. Причем часто эти вложенные view могут быть разные в зависимости от дочерней viewModel. Раньше приходилось пробрасывать резольвер или scope autofac через viewmodel чтобы вьюшка смогла создать дочерний виждет. Это выглядит допонительной перегрузкой viewmodel, тем что не требуется. Поэтому эта возможность добавлена в сам резольвер.

Документация https://github.com/QualitySolution/QSProjects/wiki/%D0%94%D0%B8%D0%B0%D0%BB%D0%BE%D0%B3%D0%B8-%D0%BF%D1%80%D0%B8%D0%BB%D0%BE%D0%B6%D0%B5%D0%BD%D0%B8%D1%8F#%D0%9A%D0%BE%D0%BD%D1%81%D1%82%D1%80%D1%83%D0%BA%D1%82%D0%BE%D1%80