### PR TITLE
Создаем исключение если запрос создан неправильно.

### DIFF
--- a/QS.Project/Project.Journal/DataLoader/DynamicQueryLoader.cs
+++ b/QS.Project/Project.Journal/DataLoader/DynamicQueryLoader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NHibernate;
+using NHibernate.Impl;
 using QS.DomainModel.Entity;
 using QS.DomainModel.UoW;
 
@@ -60,6 +61,10 @@ namespace QS.Project.Journal.DataLoader
 					return;
 				}
 
+				if (((CriteriaImpl) workQuery.UnderlyingCriteria).Session != uow.Session)
+					throw new InvalidOperationException(
+						"Метод создания запроса должен использовать переданный ему uow");
+				
 				if (pageSize.HasValue) {
 					var resultItems = workQuery.Skip(LoadedItemsCount).Take(pageSize.Value).List<TNode>();
 


### PR DESCRIPTION
В журнале очень легко ошибиться и использовать в место переданного в метод uow загрузчика, общий Uow журнала. Обычно они отличаются только заглавными или строчными буквами. Но в последствии это приводить к случайным исключениям, так как запросы вызваниваются в своем потоке. При неправильном использовании журнал часто может работать нормально, то ошибку легко пропустить, в продакшен.