### PR TITLE
Фикс InvalidCastException в DataLoader для JoinQueryOver

### DIFF
--- a/QS.Project/Project.Journal/DataLoader/DynamicQueryLoader.cs
+++ b/QS.Project/Project.Journal/DataLoader/DynamicQueryLoader.cs
@@ -61,7 +61,7 @@ namespace QS.Project.Journal.DataLoader
 					return;
 				}
 
-				if (((CriteriaImpl) workQuery.UnderlyingCriteria).Session != uow.Session)
+				if (workQuery.UnderlyingCriteria is CriteriaImpl criteriaImpl && criteriaImpl.Session != uow.Session)
 					throw new InvalidOperationException(
 						"Метод создания запроса должен использовать переданный ему uow");
 				


### PR DESCRIPTION
Временный срочный фикс JoinQueryOver.

При загрузке страницы в DataLoader запросы с JoinQueryOver (таких много), пример:

var fuelWriteoffQuery = uow.Session.QueryOver<FuelWriteoffDocument>(() => fuelWriteoffAlias)
.Left.JoinQueryOver(() => fuelWriteoffAlias.Cashier, () => cashierAlias)

возникает исключение InvalidCastException

Здесь в коде workQuery.UnderlyingCriteria будет являться Subcriteria и не может быть приведена к  CriteriaImpl.