### PR TITLE
Исправление падения на NullReference

### DIFF
--- a/QS.Project.Gtk/Dialog/EntityDialogBase.cs
+++ b/QS.Project.Gtk/Dialog/EntityDialogBase.cs
@@ -186,10 +186,12 @@ namespace QS.Dialog.Gtk
 
 		protected void OnButtonSaveClicked (object sender, EventArgs e)
 		{
+			saveButton.Sensitive = false;
 			if (!this.HasChanges || Save ()) {
 				OnEntitySaved (true);
 				OnCloseTab (false, CloseSource.Save);
-			}
+			} else
+				saveButton.Sensitive = true;
 		}
 
 		protected void OnButtonCancelClicked (object sender, EventArgs e)
@@ -232,16 +234,17 @@ namespace QS.Dialog.Gtk
 			OnButtonSaveClicked (this, EventArgs.Empty);
 		}
 
+		private Button saveButton, cancelButton;
 		//FIXME Возможно временный метод, в нем не было необходиости пока в MonoDevelop не появился баг, с удалением подписок с кнопок Save и Cancel
 		private void CheckButtonSubscription()
 		{
-			var saveButton = GtkHelper.EnumerateAllChildren(this).OfType<Button> ().FirstOrDefault (x => x.Name == "buttonSave");
+			saveButton = GtkHelper.EnumerateAllChildren(this).OfType<Button> ().FirstOrDefault (x => x.Name == "buttonSave");
 			if(saveButton != null)
 			{
 				saveButton.Clicked -= OnButtonSaveClicked;
 				saveButton.Clicked += OnButtonSaveClicked;
 			}
-			var cancelButton = GtkHelper.EnumerateAllChildren (this).OfType<Button> ().FirstOrDefault (x => x.Name == "buttonCancel");
+			cancelButton = GtkHelper.EnumerateAllChildren (this).OfType<Button> ().FirstOrDefault (x => x.Name == "buttonCancel");
 			if (cancelButton != null) {
 				cancelButton.Clicked -= OnButtonCancelClicked;
 				cancelButton.Clicked += OnButtonCancelClicked;


### PR DESCRIPTION
Во всех старых диалогах, на базе этого виджета, обнаружен эффект. Если кликнуть двойным кликом по кнопке сохранить. То первый клик выполняет начало сохранения, видимо в какой то момент, в процессе сохранения управления передается главному потоку который обрабатывает второй клик. Тем самым запускается два процесса сохранения. Один из них потом падает. Потому что к началу его выполнения uow  уже уничтожен. Засеривание кнопки сохранить после первого нажатия должно решать проблему.