### PR TITLE
Исправление засеривание кнопки Save

### DIFF
--- a/QS.Project.Gtk/Dialog/EntityDialogBase.cs
+++ b/QS.Project.Gtk/Dialog/EntityDialogBase.cs
@@ -20,6 +20,8 @@ namespace QS.Dialog.Gtk
 	public abstract class EntityDialogBase<TEntity> : TdiTabBase, IEntityDialog<TEntity>, ITdiDialog, IEntityDialog
 		where TEntity : IDomainObject, new()
 	{
+		protected bool IsDestroyed;
+
 		public IUnitOfWork UoW {
 			get {
 				return UoWGeneric;
@@ -191,7 +193,7 @@ namespace QS.Dialog.Gtk
 				OnEntitySaved (true);
 				OnCloseTab (false, CloseSource.Save);
 			}
-			if(saveButton != null)
+			if(!IsDestroyed)
 				saveButton.Sensitive = true;
 		}
 
@@ -202,7 +204,7 @@ namespace QS.Dialog.Gtk
 
 		public override void Destroy ()
 		{
-			saveButton = null; //Чтобы проверять разрушен ли уже диалог из метода OnButtonSaveClicked
+			IsDestroyed = true;
 			UoWGeneric.Dispose ();
 			base.Destroy ();
 		}

--- a/QS.Project.Gtk/Dialog/EntityDialogBase.cs
+++ b/QS.Project.Gtk/Dialog/EntityDialogBase.cs
@@ -190,7 +190,8 @@ namespace QS.Dialog.Gtk
 			if (!this.HasChanges || Save ()) {
 				OnEntitySaved (true);
 				OnCloseTab (false, CloseSource.Save);
-			} else
+			}
+			if(saveButton != null)
 				saveButton.Sensitive = true;
 		}
 
@@ -201,6 +202,7 @@ namespace QS.Dialog.Gtk
 
 		public override void Destroy ()
 		{
+			saveButton = null; //Чтобы проверять разрушен ли уже диалог из метода OnButtonSaveClicked
 			UoWGeneric.Dispose ();
 			base.Destroy ();
 		}


### PR DESCRIPTION
Все таки бывают ситуации когда попадание в метод onTabColse, не закрывает вкладку. например когда не закрыты подчиненые вкладки. 
В этом случае надо назад активировать кнопку сохранения.