### PR TITLE
Обновление класса замены ссылок на объекты

### DIFF
--- a/QS.Project/Deletion/ReplaceEntity.cs
+++ b/QS.Project/Deletion/ReplaceEntity.cs
@@ -77,10 +77,13 @@ namespace QS.Deletion
 				Progress?.Add();
 				var collPropInfo = depend.ObjectClass.GetProperty(depend.CollectionName);
 				foreach(var item in GetLinkedEntities(uow, depend, fromE)) {
-					var coll = (collPropInfo as IList);
+					var coll = (collPropInfo.GetValue(item) as IList);
 					var replaced = coll.Cast<IDomainObject>().First(x => x.Id == fromE.Id);
-					var ix = coll.IndexOf(replaced);
-					collPropInfo.SetValue(item, toE, new object[] {ix});
+					var exist = coll.Cast<IDomainObject>().FirstOrDefault(x => x.Id == toE.Id);
+					//Это правило используется для колекций связий многие к многим. Объект на который заменяем уже может быть добавлен в коллекцию, добавлять его повторно не имеет смысла.
+					coll.Remove(replaced);
+					if(exist == null)
+						coll.Add(toE);
 					uow.TrySave(item);
 					replacedLinks++;
 				}

--- a/QS.Project/Deletion/ReplaceEntity.cs
+++ b/QS.Project/Deletion/ReplaceEntity.cs
@@ -3,36 +3,55 @@ using System.Collections;
 using System.Linq;
 using NHibernate.Criterion;
 using QS.Deletion.Configuration;
+using QS.Dialog;
 using QS.DomainModel.Entity;
 using QS.DomainModel.UoW;
 
 namespace QS.Deletion
 {
-	public static class ReplaceEntity
+	/// <summary>
+	/// Класс позволяет заменять ссылки в базе с одной сущьности на другую.
+	/// Поиск зависимых объектов осуществляется на основании конфигурации удаления.
+	/// </summary>
+	public class ReplaceEntity
 	{
 		static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
-		public static int ReplaceEverywhere<TEntity>(IUnitOfWork uow, TEntity fromE, TEntity toE)
+		private readonly DeleteConfiguration configuration;
+
+		public IProgressBarDisplayable Progress;
+
+		public ReplaceEntity(DeleteConfiguration configuration)
+		{
+			this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+		}
+
+		public int ReplaceEverywhere<TEntity>(IUnitOfWork uow, TEntity fromE, TEntity toE)
 			where TEntity : IDomainObject
 		{
 			int replacedLinks = 0;
 
-			if(fromE == null || toE == null)
-				throw new ArgumentNullException("fromE || toE");
+			if(fromE == null)
+				throw new ArgumentNullException(nameof(fromE));
+			if(toE == null)
+				throw new ArgumentNullException(nameof(toE));
 			if(fromE.Id == 0)
 				throw new ArgumentException("Сущьность должна уже иметь ID", nameof(fromE));
 			if(toE.Id == 0)
 				throw new ArgumentException("Сущьность должна уже иметь ID", nameof(toE));
 
-			var delConfig = DeleteConfig.Main.GetDeleteInfo<TEntity>();
+			var delConfig = configuration.GetDeleteInfo<TEntity>();
 			if(delConfig == null)
 				throw new InvalidOperationException($"Конфигурация удаления для типа {typeof(TEntity)} не найдена.");
 
 			if( !(delConfig is IDeleteInfoHibernate))
 				throw new NotSupportedException($"Поддерживаются только конфигурации удаляения Hibernate.");
 
+			Progress?.Start(delConfig.DeleteItems.Count + delConfig.ClearItems.Count + delConfig.RemoveFromItems.Count);
+
 			foreach(var depend in delConfig.DeleteItems)
 			{
+				Progress?.Add();
 				if(String.IsNullOrEmpty(depend.PropertyName))
 					continue;
 				var propInfo = depend.ObjectClass.GetProperty(depend.PropertyName);
@@ -45,6 +64,7 @@ namespace QS.Deletion
 			}
 
 			foreach(var depend in delConfig.ClearItems) {
+				Progress?.Add();
 				var propInfo = depend.ObjectClass.GetProperty(depend.PropertyName);
 				foreach(var item in GetLinkedEntities(uow, depend, fromE)) {
 					propInfo.SetValue(item, toE, null);
@@ -54,6 +74,7 @@ namespace QS.Deletion
 			}
 
 			foreach(var depend in delConfig.RemoveFromItems) {
+				Progress?.Add();
 				var collPropInfo = depend.ObjectClass.GetProperty(depend.CollectionName);
 				foreach(var item in GetLinkedEntities(uow, depend, fromE)) {
 					var coll = (collPropInfo as IList);
@@ -65,28 +86,32 @@ namespace QS.Deletion
 				}
 			}
 
+			Progress?.Close();
 			return replacedLinks;
 		}
 
-		public static int CalculateTotalLinks<TEntity>(IUnitOfWork uow, TEntity fromE)
-	where TEntity : IDomainObject
+		public int CalculateTotalLinks<TEntity>(IUnitOfWork uow, TEntity fromE)
+			where TEntity : IDomainObject
 		{
 			logger.Info("Подсчет ссылок...");
 			int totalLinks = 0;
 
 			if(fromE == null)
-				throw new ArgumentNullException("fromE");
+				throw new ArgumentNullException(nameof(fromE));
 			if(fromE.Id == 0)
 				throw new ArgumentException("Сущьность должна уже иметь ID", nameof(fromE));
 
-			var delConfig = DeleteConfig.Main.GetDeleteInfo<TEntity>();
+			var delConfig = configuration.GetDeleteInfo<TEntity>();
 			if(delConfig == null)
 				throw new InvalidOperationException($"Конфигурация удаления для типа {typeof(TEntity)} не найдена.");
 
 			if(!(delConfig is IDeleteInfoHibernate))
 				throw new NotSupportedException($"Поддерживаются только конфигурации удаляения Hibernate.");
+			
+			Progress?.Start(delConfig.DeleteItems.Count + delConfig.ClearItems.Count + delConfig.RemoveFromItems.Count);
 
 			foreach(var depend in delConfig.DeleteItems) {
+				Progress?.Add();
 				if(String.IsNullOrEmpty(depend.PropertyName))
 					continue;
 				var propInfo = depend.ObjectClass.GetProperty(depend.PropertyName);
@@ -94,20 +119,23 @@ namespace QS.Deletion
 			}
 
 			foreach(var depend in delConfig.ClearItems) {
+				Progress?.Add();
 				var propInfo = depend.ObjectClass.GetProperty(depend.PropertyName);
 				totalLinks += GetLinkedEntities(uow, depend, fromE).Count;
 			}
 
 			foreach(var depend in delConfig.RemoveFromItems) {
+				Progress?.Add();
 				var collPropInfo = depend.ObjectClass.GetProperty(depend.CollectionName);
 				totalLinks += GetLinkedEntities(uow, depend, fromE).Count;
 			}
 
 			logger.Info("Найдено {0} ссылок.", totalLinks);
+			Progress?.Close();
 			return totalLinks;
 		}
 
-		private static IList GetLinkedEntities(IUnitOfWork uow, DeleteDependenceInfo depend, IDomainObject masterEntity)
+		private IList GetLinkedEntities(IUnitOfWork uow, DeleteDependenceInfo depend, IDomainObject masterEntity)
 		{
 			if(depend.PropertyName != null) {
 				var list = uow.Session.CreateCriteria(depend.ObjectClass)
@@ -128,7 +156,7 @@ namespace QS.Deletion
 			throw new NotImplementedException();
 		}
 
-		private static IList GetLinkedEntities(IUnitOfWork uow, RemoveFromDependenceInfo depend, IDomainObject masterEntity)
+		private IList GetLinkedEntities(IUnitOfWork uow, RemoveFromDependenceInfo depend, IDomainObject masterEntity)
 		{
 			var list = uow.Session.CreateCriteria(depend.ObjectClass)
 				.CreateAlias(depend.CollectionName, "childs")
@@ -137,13 +165,12 @@ namespace QS.Deletion
 			return list;
 		}
 
-		private static IList GetLinkedEntities(IUnitOfWork uow, ClearDependenceInfo depend, IDomainObject masterEntity)
+		private IList GetLinkedEntities(IUnitOfWork uow, ClearDependenceInfo depend, IDomainObject masterEntity)
 		{
 			var list = uow.Session.CreateCriteria(depend.ObjectClass)
 				.Add(Restrictions.Eq(depend.PropertyName + ".Id", masterEntity.Id)).List();
 
 			return list;
 		}
-
 	}
 }

--- a/QS.Project/QS.Project.csproj
+++ b/QS.Project/QS.Project.csproj
@@ -320,6 +320,7 @@
     <Compile Include="ErrorReporting\ExceptionHelper.cs" />
     <Compile Include="ErrorReporting\IErrorReportingSettings.cs" />
     <Compile Include="ErrorReporting\ReportWorker.cs" />
+    <Compile Include="Deletion\ReplaceEntity.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Project.Domain\" />

--- a/QSOrmProject/QSOrmProject.csproj
+++ b/QSOrmProject/QSOrmProject.csproj
@@ -124,7 +124,6 @@
     <Compile Include="gtk-gui\QSOrmProject.DisableSpinButton.cs" />
     <Compile Include="yWidgets\yTimeEntry.cs" />
     <Compile Include="DebugHelper\DebugLoadListener.cs" />
-    <Compile Include="Deletion\ReplaceEntity.cs" />
     <Compile Include="Domain\User.cs" />
     <Compile Include="Users\UserSettingsManager.cs" />
     <Compile Include="yWidgets\yDatePeriodPicker.cs" />
@@ -187,7 +186,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Widgets\" />
-    <Folder Include="Deletion\" />
     <Folder Include="DomainModel\" />
     <Folder Include="RepresentationModel\" />
     <Folder Include="UpdateNotification\" />


### PR DESCRIPTION
Ребята обратите внимание, изменение немного нарушает обратную совместимость. Но идеи там не сложно переписать, на нестатическую зависимость.
- Класс перемещен в новые библиотеки.
- Класс сделан не статическим, чтобы можно было использовать переданную конфигурацию удаления, а не единую для всего проекта.
- Добавлена опциональная возможность отображать прогресс операции
- Исправлен баг, в работе с коллекциями.