### PR TITLE
Изменение доступности кнопки изменить в старом журнале

### DIFF
--- a/QS.Project.Gtk/Project.Dialogs.GtkUI/JournalActions/PermissionControlledEditButton.cs
+++ b/QS.Project.Gtk/Project.Dialogs.GtkUI/JournalActions/PermissionControlledEditButton.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using QS.RepresentationModel.GtkUI;
+﻿using QS.RepresentationModel.GtkUI;
 using System.Linq;
 using QS.Services;
 
@@ -8,15 +7,21 @@ namespace QS.Project.Dialogs.GtkUI.JournalActions
 	public class PermissionControlledEditButton : RepresentationEditButton
 	{
 		private readonly IPermissionResult permission;
-
-		public PermissionControlledEditButton(IJournalDialog dialog, IRepresentationModel representationModel, IPermissionResult permission) : base(dialog, representationModel)
+		private readonly bool _customEdit;
+		
+		public PermissionControlledEditButton(
+			IJournalDialog dialog,
+			IRepresentationModel representationModel,
+			IPermissionResult permission,
+			bool customEdit = false) : base(dialog, representationModel)
 		{
 			this.permission = permission;
+			_customEdit = customEdit;
 		}
 
 		public override void CheckSensitive(object[] selected)
 		{
-			Button.Sensitive = permission.CanUpdate && selected.Any();
+			Button.Sensitive = (_customEdit ? permission.CanRead : permission.CanUpdate) && selected.Any();
 		}
 	}
 }

--- a/QS.Project.Gtk/Project.Dialogs.GtkUI/PermissionControlledRepresentationJournal.cs
+++ b/QS.Project.Gtk/Project.Dialogs.GtkUI/PermissionControlledRepresentationJournal.cs
@@ -18,8 +18,10 @@ namespace QS.Project.Dialogs.GtkUI
 		Logger logger = LogManager.GetCurrentClassLogger();
 
 		private IPermissionResult permissionResult;
+		private readonly bool _customEdit;
 
-		public PermissionControlledRepresentationJournal(IRepresentationModel representationModel, Buttons buttons = Buttons.All) : base(representationModel)
+		public PermissionControlledRepresentationJournal(
+			IRepresentationModel representationModel, Buttons buttons = Buttons.All, bool customEdit = false) : base(representationModel)
 		{
 			if(RepresentationModel.EntityType != null) {
 				UpdateUserEntityPermission();
@@ -31,6 +33,7 @@ namespace QS.Project.Dialogs.GtkUI
 			}
 
 			this.buttons = buttons;
+			_customEdit = customEdit;
 			ConfigureActionButtons();
 		}
 
@@ -49,7 +52,7 @@ namespace QS.Project.Dialogs.GtkUI
 				ActionButtons.Add(new PermissionControlledAddButton(this, RepresentationModel, permissionResult));
 			}
 			if(buttons.HasFlag(Buttons.Edit) || buttons.HasFlag(Buttons.All)) {
-				var editButton = new PermissionControlledEditButton(this, RepresentationModel, permissionResult);
+				var editButton = new PermissionControlledEditButton(this, RepresentationModel, permissionResult, _customEdit);
 				ActionButtons.Add(editButton);
 				DoubleClickAction = editButton;
 			}


### PR DESCRIPTION
Добавил булевый параметр, если нужно кнопку Изменить и двойной клик проверять на права по просмотру, а не изменению