### PR TITLE
Изменена логика создания дочерних элементов меню для всплывающего меню

### DIFF
--- a/QS.Project/Project.Journal/JournalAction.cs
+++ b/QS.Project/Project.Journal/JournalAction.cs
@@ -13,7 +13,9 @@ namespace QS.Project.Journal
 		/// <param name="sensitiveFunc">Функция проверки sensetive(отклика кнопки на нажатие), при выделенных Node-ах.</param>
 		/// <param name="visibleFunc">Функция проверки Visible(видно ли действие,к примеру,как объект выпадающего меню), при выделенных Node-ах.</param>
 		/// <param name="executeAction">Выполняемая функция, при активировании с выделенными Node-ами</param>
-		public JournalAction(string title, Func<object[], bool> sensitiveFunc, Func<object[], bool> visibleFunc, Action<object[]> executeAction = null, string hotKeys = null)
+		/// <param name="hotKeys">Горячая клавиша выполнения действия JornalAction. Записывается в виде строки: Insert, Delete, Tab</param>
+		public JournalAction(string title, Func<object[], bool> sensitiveFunc, Func<object[], bool> visibleFunc,
+			Action<object[]> executeAction = null, string hotKeys = null)
 		{
 			ChildActionsList = new List<IJournalAction>();
 			Title = title;


### PR DESCRIPTION
При текущей логике дочерние элементы во всплывающем меню не отображались, возможно я что-то забыл указать.
Заменил событие Activated на ButtonPressEvent, т.к Activated почему-то срабатывало на дочерних элементах только при нажатии на правую кнопку мыши

Обновил код вызова действий журнала при нажатии на хоткей. Теперь действия выполняются только если они Visible и Sensitive