### PR TITLE
Сохраняем в параметры базы значения с плавающей точкой в независимом от культуры формате.

### DIFF
--- a/QS.LibsTest/BaseParameters/ParametersServiceTest.cs
+++ b/QS.LibsTest/BaseParameters/ParametersServiceTest.cs
@@ -72,7 +72,7 @@ namespace QS.Test.BaseParameters
 		{
 			using (var connection = new SqliteConnection(connectionString)) {
 				MakeTable(connection);
-				connection.Execute(sqlInsert, new { name = "PI", str_value = "3,14159265359" });
+				connection.Execute(sqlInsert, new { name = "PI", str_value = "3.14159265359" });
 				dynamic parameters = new ParametersService(connection);
 				Assert.That(parameters.PI(typeof(double)), Is.EqualTo(3.14159265359d));
 			}
@@ -83,7 +83,7 @@ namespace QS.Test.BaseParameters
 		{
 			using (var connection = new SqliteConnection(connectionString)) {
 				MakeTable(connection);
-				connection.Execute(sqlInsert, new { name = "USD", str_value = "76,76" });
+				connection.Execute(sqlInsert, new { name = "USD", str_value = "76.76" });
 				dynamic parameters = new ParametersService(connection);
 				Assert.That(parameters.USD(typeof(decimal)), Is.EqualTo(76.76m));
 			}
@@ -165,7 +165,7 @@ namespace QS.Test.BaseParameters
 				parameters.VodkaPrice = 2.87m;
 				Assert.That(parameters.VodkaPrice(typeof(decimal)), Is.EqualTo(2.87m));
 				var inDB = connection.ExecuteScalar<string>(sqlSelect, new { name = "VodkaPrice" });
-				Assert.That(inDB, Is.EqualTo("2,87"));
+				Assert.That(inDB, Is.EqualTo("2.87"));
 			}
 		}
 

--- a/QS.Project/BaseParameters/ParametersService.cs
+++ b/QS.Project/BaseParameters/ParametersService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data.Common;
 using System.Dynamic;
+using System.Globalization;
 using System.Linq;
 using NLog;
 
@@ -51,7 +52,7 @@ namespace QS.BaseParameters
 			string sql;
 			if (All.ContainsKey (name))
 			{
-				if(All[name] == value.ToString())
+				if(All[name] == ConvertToString(value))
 					return;
 
 				sql = "UPDATE base_parameters SET str_value = @str_value WHERE name = @name";
@@ -68,11 +69,11 @@ namespace QS.BaseParameters
 			cmd.Parameters.Add (paramName);
 			DbParameter paramValue = cmd.CreateParameter ();
 			paramValue.ParameterName = "@str_value";
-			paramValue.Value = value.ToString();
+			paramValue.Value = ConvertToString(value);
 			cmd.Parameters.Add (paramValue);
 			cmd.ExecuteNonQuery ();
 
-			All [name] = value.ToString();
+			All [name] = ConvertToString(value);
 			logger.Debug ("Ок");
 		}
 
@@ -178,9 +179,19 @@ namespace QS.BaseParameters
 
 			TypeConverter typeConverter = TypeDescriptor.GetConverter(type);
 			if (typeConverter == null)
-				throw new NotSupportedException($"Конвертация значения в {type} не поддеживается.");
+				throw new NotSupportedException($"Конвертация значения в {type} не поддерживается.");
 
-			return typeConverter.ConvertFromString(value);
+			return typeConverter.ConvertFromInvariantString(value);
+		}
+		
+		private string ConvertToString(object value)
+		{
+			if (value is string) {
+				return (string)value;
+			}
+
+			TypeConverter typeConverter = TypeDescriptor.GetConverter(value.GetType());
+			return typeConverter.ConvertToInvariantString(value);
 		}
 
 		#endregion


### PR DESCRIPTION
Думаю это может отразится на других типах тоже.
Иначе есть шанс что параметр будет сохранен на одной культуре а прочитан на другой. Что приведет к ошибкам.
Так же это исправляет тесты.