### PR TITLE
Переключение раскладки клавиатуры на английскую при запуске программы

### DIFF
--- a/QSProjectsLib/Login.cs
+++ b/QSProjectsLib/Login.cs
@@ -64,7 +64,12 @@ namespace QSProjectsLib
 		public Login()
 		{
 			this.Build();
-			SetKeyboardLayout(EnglishLocaleId);
+
+			if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				SetKeyboardLayout(EnglishLocaleId);
+			}
+
 			SelectedConnection = String.Empty;
 			Connections = new List<Connection>();
 			DefaultServer = "localhost";

--- a/QSProjectsLib/Login.cs
+++ b/QSProjectsLib/Login.cs
@@ -39,6 +39,8 @@ namespace QSProjectsLib
 		public string DemoMessage;
 		private string server;
 		private const bool ShowPassInException = false;
+		private const int EnglishLocaleId = 1033;
+		private const uint KLF_SETFORPROCESS = 0x00000100;
 
 		static NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
 
@@ -62,6 +64,7 @@ namespace QSProjectsLib
 		public Login()
 		{
 			this.Build();
+			SetKeyboardLayout(EnglishLocaleId);
 			SelectedConnection = String.Empty;
 			Connections = new List<Connection>();
 			DefaultServer = "localhost";
@@ -374,6 +377,13 @@ namespace QSProjectsLib
 			labelKeyboardLayoutInfo.Visible = keyboardLayout != 1033; // не английская раскладка
 			labelCapslockInfo.Visible = NativeMethods.GetKeyState(capsLock) != 0;
 		}
+
+		private void SetKeyboardLayout(int localeId) 
+		{
+			var pwszKlid = localeId.ToString("x8");
+			var hkl = NativeMethods.LoadKeyboardLayout(pwszKlid, KLF_SETFORPROCESS);
+			NativeMethods.ActivateKeyboardLayout(hkl, KLF_SETFORPROCESS);
+		}
 	}
 	
 	internal class NativeMethods
@@ -386,5 +396,9 @@ namespace QSProjectsLib
 		internal static extern IntPtr GetForegroundWindow();
 		[DllImport("user32.dll")]
 		internal static extern short GetKeyState(int keyCode);
+		[DllImport("user32.dll")]
+		internal static extern uint LoadKeyboardLayout(string pwszKLID, uint Flags);
+		[DllImport("user32.dll")]
+		internal static extern uint ActivateKeyboardLayout(uint hkl, uint Flags);
 	}
 }

--- a/QSProjectsLib/Login.cs
+++ b/QSProjectsLib/Login.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -374,7 +374,7 @@ namespace QSProjectsLib
 			IntPtr foregroundWindow = NativeMethods.GetForegroundWindow();
 			uint process = NativeMethods.GetWindowThreadProcessId(foregroundWindow, IntPtr.Zero);
 			int keyboardLayout = NativeMethods.GetKeyboardLayout(process).ToInt32() & 0xFFFF;
-			labelKeyboardLayoutInfo.Visible = keyboardLayout != 1033; // не английская раскладка
+			labelKeyboardLayoutInfo.Visible = keyboardLayout != EnglishLocaleId;
 			labelCapslockInfo.Visible = NativeMethods.GetKeyState(capsLock) != 0;
 		}
 


### PR DESCRIPTION
Иногда пользователь может скопировать и вставить пароль в окно входа, не переключив раскладку на английскую, тогда не будет работать сочетание клавиш Ctrl+A в журнале.