### PR TITLE
Перемещение IDatabaseInfo в QS.Project.Core

### DIFF
--- a/QS.Project.Core/Project.DB/IDataBaseInfo.cs
+++ b/QS.Project.Core/Project.DB/IDataBaseInfo.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-namespace QS.Project.Versioning
-{
+namespace QS.Project.DB {
 	public interface IDataBaseInfo
 	{
 		/// <summary>

--- a/QS.Project.Gtk/ErrorReporting/ErrorMsgDlg.cs
+++ b/QS.Project.Gtk/ErrorReporting/ErrorMsgDlg.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -6,6 +6,7 @@ using Gtk;
 using NLog;
 using NLog.Targets;
 using QS.Dialog.GtkUI;
+using QS.Project.DB;
 using QS.Project.Domain;
 using QS.Project.Versioning;
 

--- a/QS.Project.Gtk/ErrorReporting/UnhandledExceptionHandler.cs
+++ b/QS.Project.Gtk/ErrorReporting/UnhandledExceptionHandler.cs
@@ -5,6 +5,7 @@ using GLib;
 using Gtk;
 using QS.Dialog;
 using QS.DomainModel.UoW;
+using QS.Project.DB;
 using QS.Project.Domain;
 using QS.Project.Versioning;
 using QS.Services;


### PR DESCRIPTION
По смыслу он не относится только к десктопу, в Core мне кажется ему самое место.
К тому же, понадобилось получить информацию о базе в службах на сервере, а десктоп там не нужен.