### PR TITLE
Исправление падения при удалении модели.

### DIFF
--- a/Binding/Gamma.Binding/GtkWidgets/yTreeView.cs
+++ b/Binding/Gamma.Binding/GtkWidgets/yTreeView.cs
@@ -102,12 +102,9 @@ namespace Gamma.GtkWidgets
 			set {
 				if(yTreeModel == value)
 					return;
-				IDisposable toDispose = null;
+				IDisposable toDispose = yTreeModel as IDisposable;
 				if(yTreeModel != null) {
 					yTreeModel.RenewAdapter -= YTreeModel_RenewAdapter;
-					if(yTreeModel is IDisposable disposable) {
-						toDispose = disposable;
-					}
 				}
 
 				yTreeModel = value;

--- a/Binding/Gamma.Binding/GtkWidgets/yTreeView.cs
+++ b/Binding/Gamma.Binding/GtkWidgets/yTreeView.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -102,10 +102,11 @@ namespace Gamma.GtkWidgets
 			set {
 				if(yTreeModel == value)
 					return;
+				IDisposable toDispose = null;
 				if(yTreeModel != null) {
 					yTreeModel.RenewAdapter -= YTreeModel_RenewAdapter;
-					if(yTreeModel is IDisposable model) {
-						model.Dispose();
+					if(yTreeModel is IDisposable disposable) {
+						toDispose = disposable;
 					}
 				}
 
@@ -113,6 +114,7 @@ namespace Gamma.GtkWidgets
 				if(yTreeModel != null)
 					yTreeModel.RenewAdapter += YTreeModel_RenewAdapter;
 				Model = yTreeModel == null ? null : yTreeModel.Adapter;
+				toDispose?.Dispose();
 			}
 		}
 
@@ -518,11 +520,10 @@ namespace Gamma.GtkWidgets
 				}
 			}
 
+			base.Destroy();
 			if(YTreeModel is IDisposable model) {
 				model.Dispose();
 			}
-
-			base.Destroy();
 		}
 	}
 }


### PR DESCRIPTION
Как выяснилось, на линуксе при старом варианте GTK обращался к модели, после того как мы ее очистили. Поэтому фикс просто сдвигает очистку на потом.