### PR TITLE
исправил поиск главной страницы

### DIFF
--- a/QS.Project.Desktop/Navigation/NavigationManagerBase.cs
+++ b/QS.Project.Desktop/Navigation/NavigationManagerBase.cs
@@ -78,10 +78,8 @@ namespace QS.Navigation
 
 		#region Поиск
 
-		public virtual IPage FindPage(DialogViewModelBase viewModel)
-		{
-			return AllPages.FirstOrDefault(x => x.ViewModel == viewModel);
-		}
+		public virtual IPage FindPage(DialogViewModelBase viewModel) =>
+			viewModel is null ? null : AllPages.FirstOrDefault(x => x.ViewModel == viewModel);
 
 		//Внимание здесь специально параметр viewModel не является типом приведения результата TViewModel, так как если 
 		//бы viewModel была типом TViewModel, то в вызове можно было бы не указывать Generic тип, а это бы приводило к 

--- a/QS.Project.Gtk/Navigation/TdiNavigationManager.cs
+++ b/QS.Project.Gtk/Navigation/TdiNavigationManager.cs
@@ -226,10 +226,8 @@ namespace QS.Navigation
 
 		public IPage CurrentPage => FindOrCreatePage(tdiNotebook.CurrentTab);
 
-		public virtual IPage FindPage(ITdiTab tab)
-		{
-			return AllPages.OfType<ITdiPage>().FirstOrDefault(x => x.TdiTab == tab);
-		}
+		public virtual IPage FindPage(ITdiTab tab) =>
+			tab is null ? null : AllPages.OfType<ITdiPage>().FirstOrDefault(x => x.TdiTab == tab);
 
 		private IPage FindOrCreatePage(ITdiTab tab)
 		{


### PR DESCRIPTION
если передаем null то и не должно возвращаться никакой открытой страницы, иначе если это журнал, то эти вкладки могут открываться через слайдер.

Например, открыли журнал, как Tdi вкладку, у нее viewModel будет null, затем открываем любую другую вкладку не указывая подчиненную и навигатор подтянет открытую Tdi, как мастер вкладку.

Для Tdi навигатора добавил для острастки, хотя таких ситуаций с ним не должно возникать, но и пробегать не будет всю коллекцию а сразу вернет null