### PR TITLE
Фикс снятия засеривания кнопок в виджете банковских счетов организации

### DIFF
--- a/Modules/QSBanks/AccountsView.cs
+++ b/Modules/QSBanks/AccountsView.cs
@@ -71,7 +71,7 @@ namespace QSBanks
 		void OnSelectionChanged (object sender, EventArgs e)
 		{
 			bool selected = datatreeviewAccounts.Selection.CountSelectedRows () > 0;
-			buttonEdit.Sensitive = buttonDelete.Sensitive = selected;
+			buttonEdit.Sensitive = buttonDelete.Sensitive = selected && CanEdit;
 		}
 
 		protected void OnButtonAddClicked (object sender, EventArgs e)


### PR DESCRIPTION
Если редактирование счетов недоступно, то кнопки должны быть неактивны.
Но если в списке счетов выделить строку, то засеривание кнопок снимается и пользователь может удалить счет.