### PR TITLE
Фикс скролла в журналах

### DIFF
--- a/QS.Project.Gtk/Journal.GtkUI/JournalView.cs
+++ b/QS.Project.Gtk/Journal.GtkUI/JournalView.cs
@@ -24,6 +24,7 @@ namespace QS.Journal.GtkUI
 		private readonly IGtkViewResolver viewResolver;
 		private static Logger logger = LogManager.GetCurrentClassLogger();
 		private Menu _popupMenu;
+		private bool isRedrawInProgress;
 
 		#region Глобальные настройки
 
@@ -170,10 +171,13 @@ namespace QS.Journal.GtkUI
 
 				SetItemsSource();
 
-				if(!ViewModel.DataLoader.FirstPage) {
+				if(!ViewModel.DataLoader.FirstPage || ViewModel.DataLoader.UsePreviousPageSize) {
+					isRedrawInProgress = true;
 					GtkHelper.WaitRedraw();
-					if(GtkScrolledWindow?.Vadjustment != null)
+					if(GtkScrolledWindow?.Vadjustment != null) {
 						GtkScrolledWindow.Vadjustment.Value = lastScrollPosition;
+					}
+					isRedrawInProgress = false;
 				}
 
 				if(ViewModel.ExpandAfterReloading) {
@@ -279,7 +283,7 @@ namespace QS.Journal.GtkUI
 
 		void Vadjustment_ValueChanged(object sender, EventArgs e)
 		{
-			if(!ViewModel.DataLoader.DynamicLoadingEnabled || GtkScrolledWindow.Vadjustment.Value + GtkScrolledWindow.Vadjustment.PageSize < GtkScrolledWindow.Vadjustment.Upper)
+			if(!ViewModel.DataLoader.DynamicLoadingEnabled || GtkScrolledWindow.Vadjustment.Value + GtkScrolledWindow.Vadjustment.PageSize < GtkScrolledWindow.Vadjustment.Upper ||  isRedrawInProgress)
 				return;
 
 			if(ViewModel.DataLoader.HasUnloadedItems) {
@@ -375,6 +379,7 @@ namespace QS.Journal.GtkUI
 				if(ViewModel.RowActivatedAction.GetSensitivity(selectedItems))
 				{
 					ViewModel.RowActivatedAction.ExecuteAction(selectedItems);
+					lastScrollPosition = GtkScrolledWindow.Vadjustment?.Value ?? 0;
 				}
 			}
 			else
@@ -394,6 +399,7 @@ namespace QS.Journal.GtkUI
 
 		private void ExecuteActionForWidget(object widget) {
 			if(_widgetsWithJournalActions.ContainsKey(widget)) {
+				lastScrollPosition = GtkScrolledWindow.Vadjustment?.Value ?? 0;
 				_widgetsWithJournalActions[widget].ExecuteAction(GetSelectedItems());
 			}
 		}
@@ -508,6 +514,7 @@ namespace QS.Journal.GtkUI
 		}
 
 		private bool isDestroyed = false;
+
 		public override void Destroy()
 		{
 			isDestroyed = true;

--- a/QS.Project/Project.Journal/DataLoader/AnyDataLoader.cs
+++ b/QS.Project/Project.Journal/DataLoader/AnyDataLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
@@ -44,6 +44,8 @@ namespace QS.Project.Journal.DataLoader
 
 		public uint? TotalCount => (uint?)Items?.Count;
 
+		public bool UsePreviousPageSize => false;
+
 		public event EventHandler ItemsListUpdated;
 		public event EventHandler TotalCountChanged;
 		public event EventHandler<LoadingStateChangedEventArgs> LoadingStateChanged;
@@ -71,7 +73,7 @@ namespace QS.Project.Journal.DataLoader
 		#region Загрузка данных
 		private int reloadRequested = 0;
 
-		public void LoadData(bool nextPage)
+		public void LoadData(bool nextPage, bool usePreviousPageSize = false)
 		{
 			if(cts.IsCancellationRequested)
 				cts = new CancellationTokenSource();

--- a/QS.Project/Project.Journal/DataLoader/IDataLoader.cs
+++ b/QS.Project/Project.Journal/DataLoader/IDataLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using QS.DomainModel.UoW;
@@ -47,11 +47,13 @@ namespace QS.Project.Journal.DataLoader
 
 		void GetTotalCount();
 
-		void LoadData(bool nextPage);
+		void LoadData(bool nextPage, bool usePreviousPageSize = false);
 
 		IEnumerable<object> GetNodes(int entityId, IUnitOfWork uow);
 
 		void CancelLoading();
+
+		bool UsePreviousPageSize { get; }
 	}
 
 	/// <summary>

--- a/QS.Project/Project.Journal/JournalViewModelBase.cs
+++ b/QS.Project/Project.Journal/JournalViewModelBase.cs
@@ -47,9 +47,9 @@ namespace QS.Project.Journal
 
 		public virtual IJournalAction RowActivatedAction { get; protected set; }
 
-		public void Refresh()
+		public void Refresh(bool usePreviouspageSize = false)
 		{
-			DataLoader.LoadData(false);
+			DataLoader.LoadData(false, usePreviouspageSize);
 		}
 
 		private JournalSelectionMode? tableSelectionMode;
@@ -150,7 +150,7 @@ namespace QS.Project.Journal
 
 		private void OnEntitiesUpdated(EntityChangeEvent[] changeEvents)
 		{
-			Refresh();
+			Refresh(true);
 		}
 
 		public override void Dispose()


### PR DESCRIPTION
1. После редактирования записи журнала загружать то же самое кол-во строк, что было перед редактированием.
2. После загрузки строк возвращаться на ту позицию, которая была до вызова диалога редактирования строки.
3. Исправлен баг, когда при скролле вместо одного следующего списка из 100 строк подгружается несколько раз по 100 строк.