### PR TITLE
Исправление OdtWorks

### DIFF
--- a/Modules/QSDocTemplates/OdtWorks.cs
+++ b/Modules/QSDocTemplates/OdtWorks.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -186,7 +186,7 @@ namespace QSDocTemplates
 
 			foreach (XmlNode node in content.SelectNodes ("/office:document-content/office:body/office:text/text:user-field-decls/text:user-field-decl", nsMgr)) {
 				string fieldName = node.Attributes ["text:name"].Value;
-				var field = DocParser.FieldsList.Find (f => fieldName.StartsWith (f.Name));
+				var field = DocParser.FieldsList.FirstOrDefault(f => fieldName == f.Name) ?? DocParser.FieldsList.Find (f => fieldName.StartsWith (f.Name));
 				if (field == null) {
 					logger.Warn ("Поле {0} не найдено, поэтому пропущено.", fieldName);
 					continue;


### PR DESCRIPTION
Исправлен косяк при парсинге, с обратной совместимостью:
- Если поле полностью соответствует, но есть поле с именем, название которого входит в название другого поля - значение перезаписывается
- Чтобы не ломать обратную совместимость добавлено как предварительное условие