### PR TITLE
Фикс получения свойств у наследуемых классов

### DIFF
--- a/QS.HistoryLog/Domain/FieldChange.cs
+++ b/QS.HistoryLog/Domain/FieldChange.cs
@@ -1,18 +1,13 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Reflection;
-using System.Security.Principal;
-using FluentNHibernate.Utils;
 using NHibernate.Event;
 using NHibernate.Type;
-using NHibernate.Util;
 using QS.DomainModel.Entity;
 using QS.DomainModel.Tracking;
 using QS.Project.DB;
+using QS.Utilities.Extensions;
+using System;
+using System.Reflection;
 
-namespace QS.HistoryLog.Domain
-{
+namespace QS.HistoryLog.Domain {
 	public class FieldChange : FieldChangeBase
 	{
 		#region Конфигурация
@@ -201,7 +196,8 @@ namespace QS.HistoryLog.Domain
 			IType propType = persister.PropertyTypes[i];
 			string propName = persister.PropertyNames[i];
 
-			var propInfo = persister.MappedClass.GetProperty(propName);
+			PropertyInfo propInfo = persister.MappedClass.GetPropertyInfo(propName);
+
 			if(propInfo.GetCustomAttributes(typeof(IgnoreHistoryTraceAttribute), true).Length > 0)
 				return null;
 

--- a/QS.HistoryLog/HistoryObjectDesc.cs
+++ b/QS.HistoryLog/HistoryObjectDesc.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using QS.DomainModel.Entity;
 using QS.Project.DB;
+using QS.Utilities.Extensions;
 using QS.Utilities.Text;
 
 namespace QS.HistoryLog
@@ -19,7 +20,7 @@ namespace QS.HistoryLog
 
 				foreach(var propertyMap in persistent.PropertyIterator)
 				{
-					var propInfo = persistent.MappedClass.GetProperty(propertyMap.Name);
+					var propInfo = persistent.MappedClass.GetPropertyInfo(propertyMap.Name);
 					if(propInfo.GetCustomAttributes(typeof(IgnoreHistoryTraceAttribute), true).Length > 0)
 						continue;
 

--- a/QS.Utilities/Extensions/TypeExtensions.cs
+++ b/QS.Utilities/Extensions/TypeExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace QS.Utilities.Extensions {
+	public static class TypeExtensions {
+		/// <summary>
+		/// Получение информации о свойстве<br/>
+		/// Получает информацию о свойстве, с приоритетом из указанного типа, по отношению к родительским классам<br/>
+		/// Отрабатывает при наличии new у перезаписываемого свойства с измененным типом у наследника
+		/// </summary>
+		/// <param name="mappedClass">Подключенный к БД класс</param>
+		/// <param name="propName">Имя свойства</param>
+		/// <returns></returns>
+		public static PropertyInfo GetPropertyInfo(this Type mappedClass, string propName) {
+			return mappedClass
+				.GetProperties()
+				.Where(x => x.Name == propName)
+				.OrderByDescending(x => x.DeclaringType == mappedClass)
+				.FirstOrDefault();
+		}
+	}
+}


### PR DESCRIPTION
Исправление позволяет точно получить свойство без AmbiguousMatchException, в случаяъ когда в классе используется ствойство с модицикатором new и отличающимся типом от родительского свойства.
Но получает оно из класса который указывается в аргументе метода, родительские классы игнорируются. 