### PR TITLE
Исправлена ошибка в editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,4 @@
-﻿# Remove the line below if you want to inherit .editorconfig settings from higher directories
-root = true
-
-[*]
+﻿[*]
 end_of_line = lf
 charset = utf-8
 indent_style = tab


### PR DESCRIPTION
Для библиотеки этого параметра там быть не должно, так как если она используется как модуль, то корневым editorconfig в библиотеке - быть не может