### PR TITLE
реализация интерфейса IList

### DIFF
--- a/QS.Extensions.Observable/Collections/List/ObservableList.cs
+++ b/QS.Extensions.Observable/Collections/List/ObservableList.cs
@@ -33,7 +33,7 @@ namespace QS.Extensions.Observable.Collections.List
 		public event PropertyChangedEventHandler PropertyChanged;
 
 		public new T this[int index] { 
-			get { return base[index]; } 
+			get => base[index];
 			set {
 				var oldItem = base[index];
 				base[index] = value;
@@ -42,10 +42,20 @@ namespace QS.Extensions.Observable.Collections.List
 			}
 		}
 
+		object IList.this[int index] {
+			get => this[index];
+			set => this[index] = (T)value;
+		}
+		
 		public new void Add(T item) {
 			base.Add(item);
 			OnItemAdded(item);
 			SubscribeElementChanged(item);
+		}
+		
+		int IList.Add(object value) {
+			Add((T)value);
+			return Count - 1;
 		}
 
 		public new void Clear() {
@@ -54,10 +64,18 @@ namespace QS.Extensions.Observable.Collections.List
 			ClearSubscribes();
 		}
 
+		void IList.Clear() {
+			Clear();
+		}
+
 		public new void Insert(int index, T item) {
 			base.Insert(index, item);
 			OnItemInserted(index, item);
 			SubscribeElementChanged(item);
+		}
+
+		void IList.Insert(int index, object value) {
+			Insert(index, (T)value);
 		}
 
 		public new bool Remove(T item) {
@@ -70,12 +88,20 @@ namespace QS.Extensions.Observable.Collections.List
 			return result;
 		}
 
+		void IList.Remove(object item) {
+			Remove((T)item);
+		}
+
 		public new void RemoveAt(int index) {
 			T item = this[index];
 
 			base.RemoveAt(index);
 			OnItemRemoved(item, index);
 			UnsubscribeElementChanged(item);
+		}
+
+		void IList.RemoveAt(int index) {
+			RemoveAt(index);
 		}
 
 		#region INotifyCollectionChanged Members

--- a/QS.Extensions.Observable/Collections/List/PersistentGenericObservableBag.cs
+++ b/QS.Extensions.Observable/Collections/List/PersistentGenericObservableBag.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using NHibernate.Collection.Generic;
 using NHibernate.Engine;
 using System.Collections.Generic;
@@ -32,11 +33,21 @@ namespace QS.Extensions.Observable.Collections.List {
 				SubscribeElementChanged(value);
 			}
 		}
+		
+		object IList.this[int index] {
+			get => this[index];
+			set => this[index] = (T)value;
+		}
 
 		public new void Add(T item) {
 			base.Add(item);
 			OnItemAdded(item);
 			SubscribeElementChanged(item);
+		}
+		
+		int IList.Add(object value) {
+			Add((T)value);
+			return Count - 1;
 		}
 
 		public new void Clear() {
@@ -44,11 +55,19 @@ namespace QS.Extensions.Observable.Collections.List {
 			OnCollectionReset();
 			ClearSubscribes();
 		}
+		
+		void IList.Clear() {
+			Clear();
+		}
 
 		public new void Insert(int index, T item) {
 			base.Insert(index, item);
 			OnItemInserted(index, item);
 			SubscribeElementChanged(item);
+		}
+		
+		void IList.Insert(int index, object value) {
+			Insert(index, (T)value);
 		}
 
 		public new bool Remove(T item) {
@@ -60,6 +79,10 @@ namespace QS.Extensions.Observable.Collections.List {
 
 			return result;
 		}
+		
+		void IList.Remove(object item) {
+			Remove((T)item);
+		}
 
 		public new void RemoveAt(int index) {
 			T item = this[index];
@@ -67,6 +90,10 @@ namespace QS.Extensions.Observable.Collections.List {
 			base.RemoveAt(index);
 			OnItemRemoved(item, index);
 			UnsubscribeElementChanged(item);
+		}
+		
+		void IList.RemoveAt(int index) {
+			RemoveAt(index);
 		}
 		
 		public int RemoveAll(Predicate<T> match) {


### PR DESCRIPTION
специально реализуем интерфейс IList, чтобы можно было прикастить классы ObservableList и PersistanseObservableBag к IList без потери автообновления UI, т.к. будут также вызываться нужные события